### PR TITLE
fix: improve python tests speed

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -50,10 +50,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYROSCOPE_DETECT_SUBPROCESSES: [1, 0]
-        PYROSCOPE_ONCPU: [1, 0]
-        PYROSCOPE_GIL_ONLY: [1, 0]
-        PYROSCOPE_NATIVE: [1, 0]
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['linux-build']
     name: Linux Test
@@ -80,10 +76,6 @@ jobs:
           PYROSCOPE_RUN_ID: ${{ github.run_id }}
           PYROSCOPE_ARCH: x86-64-linux
           PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYROSCOPE_DETECT_SUBPROCESSES: ${{ matrix.PYROSCOPE_DETECT_SUBPROCESSES }}
-          PYROSCOPE_ONCPU: ${{ matrix.PYROSCOPE_ONCPU }}
-          PYROSCOPE_GIL_ONLY: ${{ matrix.PYROSCOPE_GIL_ONLY }}
-          PYROSCOPE_NATIVE: ${{ matrix.PYROSCOPE_NATIVE }}
           PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
 
   linux-arm-build:
@@ -159,10 +151,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYROSCOPE_DETECT_SUBPROCESSES: [1, 0]
-        PYROSCOPE_ONCPU: [1, 0]
-        PYROSCOPE_GIL_ONLY: [1, 0]
-        PYROSCOPE_NATIVE: [1, 0]
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['macos-build']
     name: Macos Test
@@ -193,10 +181,6 @@ jobs:
           PYROSCOPE_RUN_ID: ${{ github.run_id }}
           PYROSCOPE_ARCH: x86-64-apple-darwin
           PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYROSCOPE_DETECT_SUBPROCESSES: ${{ matrix.PYROSCOPE_DETECT_SUBPROCESSES }}
-          PYROSCOPE_ONCPU: ${{ matrix.PYROSCOPE_ONCPU }}
-          PYROSCOPE_GIL_ONLY: ${{ matrix.PYROSCOPE_GIL_ONLY }}
-          PYROSCOPE_NATIVE: ${{ matrix.PYROSCOPE_NATIVE }}
           PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
  
   sdist-build:

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -54,6 +54,10 @@ jobs:
     needs: ['linux-build']
     name: Linux Test
     runs-on: ubuntu-latest
+    env:
+      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+      PYROSCOPE_ARCH: x86-64-apple-darwin
+      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -70,13 +74,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Run Python Script
-        run: python pyroscope_ffi/python/scripts/tests/test.py
-        env:
-          PYROSCOPE_RUN_ID: ${{ github.run_id }}
-          PYROSCOPE_ARCH: x86-64-linux
-          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
 
   linux-arm-build:
     strategy:
@@ -154,7 +159,11 @@ jobs:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['macos-build']
     name: Macos Test
-    runs-on: macos-11.0 
+    runs-on: macos-11.0
+    env:
+      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+      PYROSCOPE_ARCH: x86-64-apple-darwin
+      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -175,14 +184,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Run Python Script
-        run: python pyroscope_ffi/python/scripts/tests/test.py
-        env:
-          PYROSCOPE_RUN_ID: ${{ github.run_id }}
-          PYROSCOPE_ARCH: x86-64-apple-darwin
-          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
- 
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
+
   sdist-build:
     name: sdist
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -229,10 +229,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYROSCOPE_DETECT_SUBPROCESSES: [1, 0]
-        PYROSCOPE_ONCPU: [1, 0]
-        PYROSCOPE_GIL_ONLY: [1, 0]
-        PYROSCOPE_NATIVE: [1, 0]
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['windows-build']
     name: Windows Test
@@ -263,10 +259,6 @@ jobs:
           PYROSCOPE_RUN_ID: ${{ github.run_id }}
           PYROSCOPE_ARCH: x86_64-pc-windows-gnu
           PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYROSCOPE_DETECT_SUBPROCESSES: ${{ matrix.PYROSCOPE_DETECT_SUBPROCESSES }}
-          PYROSCOPE_ONCPU: ${{ matrix.PYROSCOPE_ONCPU }}
-          PYROSCOPE_GIL_ONLY: ${{ matrix.PYROSCOPE_GIL_ONLY }}
-          PYROSCOPE_NATIVE: ${{ matrix.PYROSCOPE_NATIVE }}
           PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
   sdist-build:
     name: sdist

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -254,7 +254,7 @@ jobs:
         with:
           submodules: recursive
       - name: Run Python Script
-        run: pyroscope_ffi/python/scripts/tests/test.py
+        run: python pyroscope_ffi/python/scripts/tests/test.py
         env:
           PYROSCOPE_RUN_ID: ${{ github.run_id }}
           PYROSCOPE_ARCH: x86_64-pc-windows-gnu

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -183,80 +183,80 @@ jobs:
       - run: python pyroscope_ffi/python/scripts/tests/test.py
 
 
-  windows-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - windows-version: "2022"
-            target: x86_64-pc-windows-gnu
-            py-platform: win_amd64
-
-    name: windows - ${{ matrix.py-platform }}
-    runs-on: windows-${{ matrix.windows-version }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
-          override: true
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-
-      - name: Build Wheel
-        run: |
-          pip install wheel
-          python3 setup.py bdist_wheel -p ${{ matrix.py-platform }}
-        working-directory: pyroscope_ffi/python
-        env:
-          CARGO_BUILD_TARGET: ${{ matrix.target }}
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.target }}
-          path: pyroscope_ffi/python/dist/*
-  
-  windows-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
-    needs: ['windows-build']
-    name: Windows Test
-    runs-on: windows-2022
-    env:
-      PYROSCOPE_RUN_ID: ${{ github.run_id }}
-      PYROSCOPE_ARCH: x86_64-pc-windows-gnu
-      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
-    steps:
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION }}
-          architecture: x64
-      - uses: actions/download-artifact@master
-        with:
-          name: x86_64-pc-windows-gnu
-          path: "${{github.workspace}}/python"
-
-      - run: "python --version"
-      - run: "python3 --version"
-      - run: "cd ${{ github.workspace }}/python && ls"
-      - run: |
-          cd ${{ github.workspace }}/python
-          foreach($file in Get-ChildItem -Filter *.whl){pip install $file}
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py
+#  windows-build:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - windows-version: "2022"
+#            target: x86_64-pc-windows-gnu
+#            py-platform: win_amd64
+#
+#    name: windows - ${{ matrix.py-platform }}
+#    runs-on: windows-${{ matrix.windows-version }}
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          toolchain: stable
+#          target: ${{ matrix.target }}
+#          profile: minimal
+#          override: true
+#
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#
+#
+#      - name: Build Wheel
+#        run: |
+#          pip install wheel
+#          python3 setup.py bdist_wheel -p ${{ matrix.py-platform }}
+#        working-directory: pyroscope_ffi/python
+#        env:
+#          CARGO_BUILD_TARGET: ${{ matrix.target }}
+#
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: ${{ matrix.target }}
+#          path: pyroscope_ffi/python/dist/*
+#
+#  windows-test:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
+#    needs: ['windows-build']
+#    name: Windows Test
+#    runs-on: windows-2022
+#    env:
+#      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+#      PYROSCOPE_ARCH: x86_64-pc-windows-gnu
+#      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+#      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+#    steps:
+#      - name: Set up Python
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.PYTHON_VERSION }}
+#          architecture: x64
+#      - uses: actions/download-artifact@master
+#        with:
+#          name: x86_64-pc-windows-gnu
+#          path: "${{github.workspace}}/python"
+#
+#      - run: "python --version"
+#      - run: "python3 --version"
+#      - run: "cd ${{ github.workspace }}/python && ls"
+#      - run: |
+#          cd ${{ github.workspace }}/python
+#          foreach($file in Get-ChildItem -Filter *.whl){pip install $file}
+#      - uses: actions/checkout@v2
+#        with:
+#          submodules: recursive
+#      - run: python pyroscope_ffi/python/scripts/tests/test.py
 
   sdist-build:
     name: sdist

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -55,6 +55,11 @@ jobs:
     needs: ['linux-build']
     name: Linux Test
     runs-on: ubuntu-latest
+    env:
+      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+      PYROSCOPE_ARCH: x86-64-linux
+      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -71,13 +76,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Run Python Script
-        run: python pyroscope_ffi/python/scripts/tests/test.py
-        env:
-          PYROSCOPE_RUN_ID: ${{ github.run_id }}
-          PYROSCOPE_ARCH: x86-64-linux
-          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
 
   linux-arm-build:
     strategy:
@@ -155,7 +161,12 @@ jobs:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['macos-build']
     name: Macos Test
-    runs-on: macos-11.0 
+    runs-on: macos-11.0
+    env:
+      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+      PYROSCOPE_ARCH: x86-64-apple-darwin
+      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -176,13 +187,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Run Python Script
-        run: python pyroscope_ffi/python/scripts/tests/test.py
-        env:
-          PYROSCOPE_RUN_ID: ${{ github.run_id }}
-          PYROSCOPE_ARCH: x86-64-apple-darwin
-          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
  
 
   windows-build:
@@ -233,6 +245,11 @@ jobs:
     needs: ['windows-build']
     name: Windows Test
     runs-on: windows-2022
+    env:
+      PYROSCOPE_RUN_ID: ${{ github.run_id }}
+      PYROSCOPE_ARCH: x86_64-pc-windows-gnu
+      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+      PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -253,13 +270,15 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Run Python Script
-        run: python pyroscope_ffi/python/scripts/tests/test.py
-        env:
-          PYROSCOPE_RUN_ID: ${{ github.run_id }}
-          PYROSCOPE_ARCH: x86_64-pc-windows-gnu
-          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
-          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
+      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
+
   sdist-build:
     name: sdist
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -76,14 +76,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py
 
   linux-arm-build:
     strategy:
@@ -187,15 +180,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
- 
+      - run: python pyroscope_ffi/python/scripts/tests/test.py
+
 
   windows-build:
     strategy:
@@ -270,14 +256,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
+      - run: python pyroscope_ffi/python/scripts/tests/test.py
 
   sdist-build:
     name: sdist

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -54,10 +54,6 @@ jobs:
     needs: ['linux-build']
     name: Linux Test
     runs-on: ubuntu-latest
-    env:
-      PYROSCOPE_RUN_ID: ${{ github.run_id }}
-      PYROSCOPE_ARCH: x86-64-apple-darwin
-      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -74,14 +70,13 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
+      - name: Run Python Script
+        run: python pyroscope_ffi/python/scripts/tests/test.py
+        env:
+          PYROSCOPE_RUN_ID: ${{ github.run_id }}
+          PYROSCOPE_ARCH: x86-64-linux
+          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
 
   linux-arm-build:
     strategy:
@@ -159,11 +154,7 @@ jobs:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9', '3.10']
     needs: ['macos-build']
     name: Macos Test
-    runs-on: macos-11.0
-    env:
-      PYROSCOPE_RUN_ID: ${{ github.run_id }}
-      PYROSCOPE_ARCH: x86-64-apple-darwin
-      PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+    runs-on: macos-11.0 
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -184,15 +175,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py false true true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true false true
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true false
-      - run: python pyroscope_ffi/python/scripts/tests/test.py true true true
-
+      - name: Run Python Script
+        run: python pyroscope_ffi/python/scripts/tests/test.py
+        env:
+          PYROSCOPE_RUN_ID: ${{ github.run_id }}
+          PYROSCOPE_ARCH: x86-64-apple-darwin
+          PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
+          PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
+ 
   sdist-build:
     name: sdist
     runs-on: ubuntu-latest

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -103,16 +103,24 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
 
     thread_1 = threading.Thread(target=multihash, args=('abc',))
     thread_2 = threading.Thread(target=multihash2, args=('abc',))
-
     thread_1.start()
     thread_2.start()
 
-    signal.alarm(120)
+    def watchdog():
+        logging.info('Watchdog expired. Test timeout. Exiting...')
+        exit(7)
+
+    alarm = threading.Timer(120, watchdog)
+    alarm.start()
 
     wait_render(canary)
 
+    alarm.cancel()
+
     pyroscope.shutdown()
+
     logging.info("done")
+
     event.set()
     thread_1.join()
     thread_2.join()

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -44,20 +44,20 @@ def wait_render(canary):
         time.sleep(2)
         u = 'https://pyroscope.cloud/render?from=now-1h&until=now&format=collapsed&query=' \
             + '{}.cpu%7Bcanary%3D%22{}%22%7D'.format(app_name, canary)
+        response = None
         try:
             logging.info('render %s', u)
             req = Request(u)
             req.add_header('Authorization', 'Bearer {}'.format(token))
-            with urlopen(req) as response:
-                code = response.getcode()
-                # print(code)
-                # print(response)
-                # print(dir(response))
-                body = response.read()
-                logging.info("render body %s", body.decode('utf-8'))
-                if code == 200 and body != b'' and b'multihash' in body:
-                    return
+            response = urlopen(req)
+            code = response.getcode()
+            body = response.read()
+            logging.info("render body %s", body.decode('utf-8'))
+            if code == 200 and body != b'' and b'multihash' in body:
+                return
         except Exception:
+            if response is not None:
+                response.close()
             traceback.print_exc()
             continue
 

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -44,22 +44,22 @@ def wait_render(canary):
         time.sleep(2)
         u = 'https://pyroscope.cloud/render?from=now-1h&until=now&format=collapsed&query=' \
             + '{}.cpu%7Bcanary%3D%22{}%22%7D'.format(app_name, canary)
-        try:
-            logger.info('render {}', u)
-            req = Request(u)
-            req.add_header('Authorization', 'Bearer {}'.format(token))
-            with urlopen(req) as response:
-                code = response.getcode()
-                # print(code)
-                # print(response)
-                # print(dir(response))
-                body = response.read()
-                logger.info("render body {}", body)
-                if code == 200 and body != b'' and b'multihash' in body:
-                    return
-        except Exception:
-            traceback.print_exc()
-            continue
+        # try:
+        logging.info('render %s', u)
+        req = Request(u)
+        req.add_header('Authorization', 'Bearer {}'.format(token))
+        with urlopen(req) as response:
+            code = response.getcode()
+            # print(code)
+            # print(response)
+            # print(dir(response))
+            body = response.read()
+            logging.info("render body %s", body.decode('utf-8'))
+            if code == 200 and body != b'' and b'multihash' in body:
+                return
+        # except Exception:
+        #     traceback.print_exc()
+        #     continue
 
 
 def do_one_test(on_cpu, gil_only, detect_subprocesses):
@@ -67,7 +67,7 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
     if p != 0:
         return p
     canary = uuid.uuid4().hex
-    logger.info('canary {}', canary)
+    logging.info('canary %s', canary)
     runid = os.getenv("PYROSCOPE_RUN_ID")
     pyroscope.configure(
         application_name=app_name,
@@ -116,15 +116,15 @@ if __name__ == '__main__':
                 _, exitcode = os.waitpid(pid, 0)
                 name = 'on_cpu {} gil_only {}  detect_subprocesses {}'.format(on_cpu, gil_only,
                                                                               detect_subprocesses)
-                logger.info("testcase {} {} {}", pid, exitcode, name)
+                logging.info("testcase %s %s %s", pid, exitcode, name)
                 res.append((pid, exitcode, name))
 
     for testcase in res:
-        logger.info("testcase {}", testcase)
+        logging.info("testcase {}", testcase)
     for testcase in res:
         pid = testcase[0]
         exitcode = testcase[1]
         name = testcase[2]
         if exitcode != 0:
-            logger.error('testcase {} {} {} failed', pid, exitcode, name)
+            logger.error('testcase %s %s %s failed', pid, exitcode, name)
             exit(1)

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -65,6 +65,7 @@ def wait_render(canary):
 
 
 def do_one_test(on_cpu, gil_only, detect_subprocesses):
+    logging.info("do_one_test on_cpu=%s gil_only=%s detect_subprocesses=%s", on_cpu, gil_only, detect_subprocesses)
     canary = uuid.uuid4().hex
     logging.info('canary %s', canary)
     runid = os.getenv("PYROSCOPE_RUN_ID")
@@ -114,7 +115,7 @@ if __name__ == '__main__':
         for on_cpu in [True, False]:
             for gil_only in [True, False]:
                 for detect_subprocesses in [True, False]:
-                    p = multiprocessing.Process(target=do_one_test, args=(False, False, False))
+                    p = multiprocessing.Process(target=do_one_test, args=(on_cpu, gil_only, detect_subprocesses))
                     p.start()
                     p.join()
                     res.append((p.exitcode, "{} {} {}".format(on_cpu, gil_only, detect_subprocesses)))

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -9,6 +9,7 @@ import sys
 import multiprocessing
 
 import pyroscope
+import threading
 
 import uuid
 
@@ -21,6 +22,8 @@ token = os.getenv("PYROSCOPE_API_TOKEN")
 app_name = 'pyroscopers.python.test'
 logger = logging.getLogger()
 
+event = threading.Event()
+
 
 def hash(string):
     string = string.encode()
@@ -30,7 +33,7 @@ def hash(string):
 
 
 def multihash(string):
-    while True:
+    while not event.is_set():
         time.sleep(0.2)
         e = time.time() + 0.1
         while time.time() < e:
@@ -39,7 +42,7 @@ def multihash(string):
 
 
 def multihash2(string):
-    while True:
+    while not event.is_set():
         time.sleep(0.2)
         e = time.time() + 0.1
         while time.time() < e:
@@ -109,8 +112,10 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
     wait_render(canary)
 
     pyroscope.shutdown()
-
-    exit(0)
+    logging.info("done")
+    event.set()
+    thread_1.join()
+    thread_2.join()
 
 
 if __name__ == '__main__':

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -1,36 +1,20 @@
 import hashlib
 import os
+import signal
 import threading
 import logging
+import time
 
 import pyroscope
 
+import uuid
+try:
+    from urllib.request import Request, urlopen
+except ImportError:
+    from urllib2 import Request, urlopen
 
-# Set python logging level to DEBUG
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
-# Configure Pyroscope
-pyroscope.configure(
-    application_name = '{}'.format(os.getenv("PYROSCOPE_RUN_ID")),
-    server_address = "https://ingest.pyroscope.cloud",
-    auth_token     = '{}'.format(os.getenv("PYROSCOPE_API_TOKEN")),
-    enable_logging =True,
-    detect_subprocesses = os.getenv("PYROSCOPE_DETECT_SUBPROCESSES") == "true",
-    oncpu = os.getenv("PYROSCOPE_ONCPU") == "true",
-    gil_only =  os.getenv("PYROSCOPE_GIL_ONLY") == "true",
-    report_pid = True,
-    report_thread_id = True,
-    report_thread_name = True,
-    tags           = {
-        "detect_subprocesses": '{}'.format(os.getenv("PYROSCOPE_DETECT_SUBPROCESSES")),
-        "oncpu": '{}'.format(os.getenv("PYROSCOPE_ONCPU")),
-        "gil_only": '{}'.format(os.getenv("PYROSCOPE_GIL_ONLY")),
-        "version": '{}'.format(os.getenv("PYTHON_VERSION")),
-        "arch": '{}'.format(os.getenv("PYROSCOPE_ARCH")),
-    }
-)
-
+token = os.getenv("PYROSCOPE_API_TOKEN")
+app_name = 'pyroscopers.python.test'
 
 def hash(string):
     string = string.encode()
@@ -38,23 +22,100 @@ def hash(string):
 
     return string
 
+
 def multihash(string):
-    for i in range(0, 25510055):
+    for i in range(0, 25510000):
         string = hash(string)
     return string
+
 
 def multihash2(string):
-    for i in range(0, 25510055):
+    for i in range(0, 25510000):
         string = hash(string)
     return string
 
-thread_1 = threading.Thread(target=multihash, args=('abc',))
-thread_2 = threading.Thread(target=multihash2, args=('abc',))
+def wait_render(canary):
+    while True:
+        time.sleep(2)
 
-thread_1.start()
-thread_2.start()
 
-thread_1.join()
-thread_2.join()
+        u = 'https://pyroscope.cloud/render?from=now-1h&until=now&format=collapsed&query=' \
+            + '{}.cpu%7Bcanary%3D%22{}%22%7D'.format(app_name, canary)
+        print(u)
+        req = Request(u)
+        req.add_header('Authorization', 'Bearer {}'.format(token))
+        with urlopen(req) as response:
+            body = response.read()
+            print(body)
+            if body != b'':
+                return
 
-pyroscope.shutdown()
+
+def do_one_test(on_cpu, gil_only, detect_subprocesses):
+    p = os.fork()
+    if p != 0:
+        return p
+    canary = uuid.uuid4().hex
+    print('canary {}'.format(canary))
+    runid = os.getenv("PYROSCOPE_RUN_ID")
+    pyroscope.configure(
+        application_name=app_name,
+        server_address="https://ingest.pyroscope.cloud",
+        auth_token='{}'.format(token),
+        enable_logging=True,
+        detect_subprocesses=detect_subprocesses,
+        oncpu=on_cpu,
+        gil_only=gil_only,
+        report_pid=True,
+        report_thread_id=True,
+        report_thread_name=True,
+
+        tags={
+            "detect_subprocesses": '{}'.format(detect_subprocesses),
+            "oncpu": '{}'.format(on_cpu),
+            "gil_only": '{}'.format(gil_only),
+            "version": '{}'.format(os.getenv("PYTHON_VERSION")),
+            "arch": '{}'.format(os.getenv("PYROSCOPE_ARCH")),
+            "canary": canary,
+            "run_id": runid,
+        }
+    )
+
+    thread_1 = threading.Thread(target=multihash, args=('abc',))
+    thread_2 = threading.Thread(target=multihash2, args=('abc',))
+
+    thread_1.start()
+    thread_2.start()
+
+    signal.alarm(30)
+
+    wait_render(canary)
+
+    pyroscope.shutdown()
+    exit(0)
+
+
+
+if __name__ == '__main__':
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    pids = []
+    for on_cpu in [True, False]:
+        for gil_only in [True, False]:
+            for detect_subprocesses in [True, False]:
+                pid = do_one_test(on_cpu, gil_only, detect_subprocesses)
+                pids.append((pid, 'on_cpu {} gil_only {}  detect_subprocesses {}'.format(on_cpu, gil_only, detect_subprocesses)))
+    res = []
+    for testcase in pids:
+        pid = testcase[0]
+        test_name = testcase[1]
+        _, exitcode = os.waitpid(pid, 0)
+        print('pid {} {} exited with {}'.format(pid, test_name, exitcode))
+        res.append((pid, exitcode))
+    for testcase in res:
+        pid = testcase[0]
+        exitcode = testcase[1]
+        if exitcode != 0:
+            print('testcase {} failed'.format(pid))
+            exit(1)
+

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -119,10 +119,10 @@ if __name__ == '__main__':
                     p.join()
                     res.append((p.exitcode, "{} {} {}".format(on_cpu, gil_only, detect_subprocesses)))
         for t in res:
-            logging.Info("%s", str(t))
+            logging.info("%s", str(t))
         for t in res:
             if t[0] != 0:
-                logging.Error("test failed %s", str(t))
+                logging.info("test failed %s", str(t))
     else:
         on_cpu = sys.argv[1] == "true"
         gil_only = sys.argv[2] == "true"

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -63,9 +63,6 @@ def wait_render(canary):
 
 
 def do_one_test(on_cpu, gil_only, detect_subprocesses):
-    p = os.fork()
-    if p != 0:
-        return p
     canary = uuid.uuid4().hex
     logging.info('canary %s', canary)
     runid = os.getenv("PYROSCOPE_RUN_ID")
@@ -109,22 +106,8 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
 if __name__ == '__main__':
     logger.setLevel(logging.INFO)
     res = []
-    for on_cpu in [True, False]:
-        for gil_only in [True, False]:
-            for detect_subprocesses in [True, False]:
-                pid = do_one_test(on_cpu, gil_only, detect_subprocesses)
-                _, exitcode = os.waitpid(pid, 0)
-                name = 'on_cpu {} gil_only {}  detect_subprocesses {}'.format(on_cpu, gil_only,
-                                                                              detect_subprocesses)
-                logging.info("testcase %s %s %s", pid, exitcode, name)
-                res.append((pid, exitcode, name))
-
-    for testcase in res:
-        logging.info("testcase %s", str(testcase))
-    for testcase in res:
-        pid = testcase[0]
-        exitcode = testcase[1]
-        name = testcase[2]
-        if exitcode != 0:
-            logger.error('testcase %s %s %s failed', pid, exitcode, name)
-            exit(1)
+    on_cpu = sys.argv[1] == "true"
+    gil_only = sys.argv[2] == "true"
+    detect_subprocesses = sys.argv[3] == "true"
+    do_one_test(on_cpu, gil_only, detect_subprocesses)
+    

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -94,7 +94,7 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
     thread_1.start()
     thread_2.start()
 
-    signal.alarm(30)
+    signal.alarm(120)
 
     wait_render(canary)
 

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -44,22 +44,22 @@ def wait_render(canary):
         time.sleep(2)
         u = 'https://pyroscope.cloud/render?from=now-1h&until=now&format=collapsed&query=' \
             + '{}.cpu%7Bcanary%3D%22{}%22%7D'.format(app_name, canary)
-        # try:
-        logging.info('render %s', u)
-        req = Request(u)
-        req.add_header('Authorization', 'Bearer {}'.format(token))
-        with urlopen(req) as response:
-            code = response.getcode()
-            # print(code)
-            # print(response)
-            # print(dir(response))
-            body = response.read()
-            logging.info("render body %s", body.decode('utf-8'))
-            if code == 200 and body != b'' and b'multihash' in body:
-                return
-        # except Exception:
-        #     traceback.print_exc()
-        #     continue
+        try:
+            logging.info('render %s', u)
+            req = Request(u)
+            req.add_header('Authorization', 'Bearer {}'.format(token))
+            with urlopen(req) as response:
+                code = response.getcode()
+                # print(code)
+                # print(response)
+                # print(dir(response))
+                body = response.read()
+                logging.info("render body %s", body.decode('utf-8'))
+                if code == 200 and body != b'' and b'multihash' in body:
+                    return
+        except Exception:
+            traceback.print_exc()
+            continue
 
 
 def do_one_test(on_cpu, gil_only, detect_subprocesses):
@@ -120,7 +120,7 @@ if __name__ == '__main__':
                 res.append((pid, exitcode, name))
 
     for testcase in res:
-        logging.info("testcase {}", testcase)
+        logging.info("testcase %s", str(testcase))
     for testcase in res:
         pid = testcase[0]
         exitcode = testcase[1]

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -30,14 +30,20 @@ def hash(string):
 
 
 def multihash(string):
-    for i in range(0, 25510000):
-        string = hash(string)
+    while True:
+        time.sleep(0.2)
+        e = time.time() + 0.1
+        while time.time() < e:
+            string = hash(string)
     return string
 
 
 def multihash2(string):
-    for i in range(0, 25510000):
-        string = hash(string)
+    while True:
+        time.sleep(0.2)
+        e = time.time() + 0.1
+        while time.time() < e:
+            string = hash(string)
     return string
 
 
@@ -103,6 +109,7 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
     wait_render(canary)
 
     pyroscope.shutdown()
+
     exit(0)
 
 
@@ -111,19 +118,24 @@ if __name__ == '__main__':
     logger.setLevel(logging.INFO)
     multiprocessing.log_to_stderr(logging.INFO)
     if do_multiprocessing:
+        procs = []
         res = []
         for on_cpu in [True, False]:
             for gil_only in [True, False]:
                 for detect_subprocesses in [True, False]:
                     p = multiprocessing.Process(target=do_one_test, args=(on_cpu, gil_only, detect_subprocesses))
                     p.start()
-                    p.join()
-                    res.append((p.exitcode, "{} {} {}".format(on_cpu, gil_only, detect_subprocesses)))
+
+                    procs.append((p, "{} {} {}".format(on_cpu, gil_only, detect_subprocesses)))
+        for p in procs:
+            p[0].join()
+            res.append((p[0].exitcode, p[1]))
         for t in res:
             logging.info("%s", str(t))
         for t in res:
             if t[0] != 0:
                 logging.info("test failed %s", str(t))
+                exit(1)
     else:
         on_cpu = sys.argv[1] == "true"
         gil_only = sys.argv[2] == "true"

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -108,12 +108,12 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
 if __name__ == '__main__':
     do_multiprocessing = True
     logger.setLevel(logging.INFO)
+    multiprocessing.log_to_stderr(logging.INFO)
     if do_multiprocessing:
         res = []
         for on_cpu in [True, False]:
             for gil_only in [True, False]:
                 for detect_subprocesses in [True, False]:
-                    multiprocessing.log_to_stderr(logging.INFO)
                     p = multiprocessing.Process(target=do_one_test, args=(False, False, False))
                     p.start()
                     p.join()

--- a/pyroscope_ffi/python/scripts/tests/test.py
+++ b/pyroscope_ffi/python/scripts/tests/test.py
@@ -1,14 +1,15 @@
 import hashlib
 import os
 import signal
+import sys
 import threading
 import logging
 import time
 import traceback
-
 import pyroscope
-
+import platform
 import uuid
+
 try:
     from urllib.request import Request, urlopen
 except ImportError:
@@ -59,12 +60,11 @@ def wait_render(canary):
 
 
 def do_one_test(on_cpu, gil_only, detect_subprocesses):
-    p = os.fork()
-    if p != 0:
-        return p
     canary = uuid.uuid4().hex
     print('canary {}'.format(canary))
     runid = os.getenv("PYROSCOPE_RUN_ID")
+    pyver = '{}.{}'.format(sys.version_info.major, sys.version_info.minor)
+    p = platform.processor()
     pyroscope.configure(
         application_name=app_name,
         server_address="https://ingest.pyroscope.cloud",
@@ -81,8 +81,8 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
             "detect_subprocesses": '{}'.format(detect_subprocesses),
             "oncpu": '{}'.format(on_cpu),
             "gil_only": '{}'.format(gil_only),
-            "version": '{}'.format(os.getenv("PYTHON_VERSION")),
-            "arch": '{}'.format(os.getenv("PYROSCOPE_ARCH")),
+            "version": '{}'.format(pyver),
+            "arch": '{}'.format(p),
             "canary": canary,
             "run_id": runid,
         }
@@ -106,23 +106,8 @@ def do_one_test(on_cpu, gil_only, detect_subprocesses):
 if __name__ == '__main__':
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    pids = []
-    for on_cpu in [True, False]:
-        for gil_only in [True, False]:
-            for detect_subprocesses in [True, False]:
-                pid = do_one_test(on_cpu, gil_only, detect_subprocesses)
-                pids.append((pid, 'on_cpu {} gil_only {}  detect_subprocesses {}'.format(on_cpu, gil_only, detect_subprocesses)))
-    res = []
-    for testcase in pids:
-        pid = testcase[0]
-        test_name = testcase[1]
-        _, exitcode = os.waitpid(pid, 0)
-        print('pid {} {} exited with {}'.format(pid, test_name, exitcode))
-        res.append((pid, exitcode))
-    for testcase in res:
-        pid = testcase[0]
-        exitcode = testcase[1]
-        if exitcode != 0:
-            print('testcase {} failed'.format(pid))
-            exit(1)
+    on_cpu = sys.argv[1] == 'true'
+    gil_only = sys.argv[2] == 'true'
+    detect_subprocesses = sys.argv[3] == 'true'
+    do_one_test(on_cpu, gil_only, detect_subprocesses)
 


### PR DESCRIPTION
address #75 

- reduce the test matrix size in the gh action: move the matrix inside the script itself, run every testcase in a forked process
- do a /render api call, and stop the test as successful if some correct profiling data is returned