### PR TITLE
Update outdated deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,12 @@ path = "examples/internal/rbspy-connect.rs"
 [dependencies]
 thiserror ="1.0"
 log = "0.4"
-names = "0.13.0"
+names = "0.14.0"
 reqwest = { version = "0.11", features = ["blocking"], default-features = false }
 url = "2.2.2"
 libflate = "1.2.0"
 libc = "^0.2.124"
-prost = "0.10"
+prost = "0.11"
 winapi = "0.3.9"
 json = "0.12.4"
 


### PR DESCRIPTION
Bump the outdated deps. You can see it when you open the `Cargo.toml`.