### PR TITLE
pprof_rs: expose frame-pointer feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,9 +1480,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pprof"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+checksum = "6b90f8560ad8bd57b207b8293bc5226e48e89039a6e590c12a297d91b84c7e60"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -2256,9 +2256,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "symbolic-common"
-version = "10.2.1"
+version = "12.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+checksum = "167a4ffd7c35c143fd1030aa3c2caf76ba42220bd5a6b5f4781896434723b8c3"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2268,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "10.2.1"
+version = "12.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+checksum = "e378c50e80686c1c5c205674e1f86a2858bec3d2a7dfdd690331a8a19330f293"
 dependencies = [
  "cpp_demangle 0.4.2",
  "rustc-demangle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "pyroscope_pprofrs"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "log",
  "pprof",

--- a/pyroscope_backends/pyroscope_pprofrs/Cargo.toml
+++ b/pyroscope_backends/pyroscope_pprofrs/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 
 
 [dependencies]
-pprof = "0.11"
+pprof = "0.12"
 pyroscope = { version = "0.5.5", path = "../../", default-features = false }
 thiserror ="1.0"
 log = "0.4"
@@ -25,7 +25,7 @@ default = ["pyroscope/default"]
 frame-pointer = ["pprof/frame-pointer"]
 
 [target.aarch64-apple-darwin.dependencies]
-pprof = { version = "0.11", features = ["frame-pointer"] }
+pprof = { version = "0.12", features = ["frame-pointer"] }
 
 
 

--- a/pyroscope_backends/pyroscope_pprofrs/Cargo.toml
+++ b/pyroscope_backends/pyroscope_pprofrs/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 
 [features]
 default = ["pyroscope/default"]
+frame-pointer = ["pprof/frame-pointer"]
 
 [target.aarch64-apple-darwin.dependencies]
 pprof = { version = "0.11", features = ["frame-pointer"] }


### PR DESCRIPTION
Pyroscope is currently unusable with pprof-rs with the default stack unwinder: https://github.com/tikv/pprof-rs/issues/219

Frame-pointer seems to work, so let's expose it to end users
