### PR TITLE
fix spurious exit when epoll_wait is interrupted by a signal

### DIFF
--- a/src/timer/epoll.rs
+++ b/src/timer/epoll.rs
@@ -62,7 +62,12 @@ impl Timer {
                     }
 
                     // Fire @ 10th sec
-                    Timer::epoll_wait(timer_fd, epoll_fd)?;
+                    let res = Timer::epoll_wait(timer_fd, epoll_fd);
+                    if matches!(&res, Err(PyroscopeError::Io(err)) if err.kind() == std::io::ErrorKind::Interrupted)
+                    {
+                        continue;
+                    }
+                    res?;
 
                     // Get the current time range
                     let from = TimerSignal::NextSnapshot(get_time_range(0)?.from);


### PR DESCRIPTION
I discovered a hang in the pyroscope agent, that is triggered when the `Timer` thread gets interrupted by a signal.
Instead of retrying the epoll_wait call, the `Timer` thread simply exits and no data is fed into the server.

This PR checks the `epoll_wait` error and retries the call if it gets `EINTR`.
