### PR TITLE
Avoid pulling in `clap` crate by the library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,6 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "clap 3.2.25",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ path = "examples/internal/rbspy-connect.rs"
 [dependencies]
 thiserror ="1.0"
 log = "0.4"
-names = "0.14.0"
+names = { version = "0.14.0", default-features = false }
 reqwest = { version = "0.11", features = ["blocking"], default-features = false }
 url = "2.2.2"
 libflate = "1.2.0"


### PR DESCRIPTION
`names` has made questionable decision to depend on `clap` by the default which brings unnecessary dependencies for the library users: https://github.com/fnichol/names/blob/b5023b03e2339bf6e860bdcef20557ab81f3ec55/Cargo.toml#L21

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
