### PR TITLE
Clap feature tweaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,6 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "clap 3.2.25",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ path = "examples/internal/rbspy-connect.rs"
 [dependencies]
 thiserror ="1.0"
 log = "0.4"
-names = "0.14.0"
+names = { version = "0.14.0", default-features = false }
 reqwest = { version = "0.11", features = ["blocking"], default-features = false }
 url = "2.2.2"
 libflate = "1.2.0"

--- a/pyroscope_backends/pyroscope_pyspy/Cargo.toml
+++ b/pyroscope_backends/pyroscope_pyspy/Cargo.toml
@@ -18,7 +18,7 @@ py-spy = "0.3.14"
 pyroscope = { version = "0.5.7", path = "../../" , default-features = false }
 thiserror ="1.0"
 log = "0.4"
-inferno = "=0.11.14"
+inferno = { version = "=0.11.14", default-features = false, features = ["multithreaded", "nameattr"] }
 
 [features]
 default = ["pyroscope/default"]

--- a/pyroscope_backends/pyroscope_rbspy/Cargo.toml
+++ b/pyroscope_backends/pyroscope_rbspy/Cargo.toml
@@ -19,7 +19,7 @@ pyroscope = { version = "0.5.7", path = "../../", default-features = false }
 thiserror ="1.0"
 log = "0.4"
 anyhow = "1.0.56"
-inferno = "=0.11.14"
+inferno = { version = "=0.11.14", default-features = false, features = ["multithreaded", "nameattr"] }
 
 [features]
 default = ["pyroscope/default"]

--- a/pyroscope_ffi/python/lib/Cargo.toml
+++ b/pyroscope_ffi/python/lib/Cargo.toml
@@ -13,7 +13,7 @@ pyroscope = { path  = "../../../" }
 pyroscope_pyspy = { path = "../../../pyroscope_backends/pyroscope_pyspy" }
 ffikit = { path = "../../ffikit" }
 pretty_env_logger = "0.4.0"
-inferno = "=0.11.14"
+inferno = { version = "=0.11.14", default-features = false, features = ["multithreaded", "nameattr"] }
 log = "0.4"
 
 


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

(Context: sniffing out lingering sources of old clap version downloads)

`inferno` and `names` are both bin+lib crates that both use a default feature for the CLI related dependencies. Currently there are still some dependencies that are unconditionally pulling in `clap` for binary-related things even when using it as a library. I've already opened issues on both of the ones I noticed

- https://github.com/benfred/py-spy/issues/647
- https://github.com/rbspy/rbspy/issues/384