### PR TITLE
chore(ci): update rust build toolchain

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -8,7 +8,7 @@ steps:
 - commands:
   - uname -a
   - make test
-  image: pyroscope/rust_builder_cli:2
+  image: pyroscope/rust_builder_cli:3
   name: make cli/test
 trigger:
   event:
@@ -24,7 +24,7 @@ steps:
 - commands:
   - uname -a
   - make test
-  image: pyroscope/rust_builder_cli:2
+  image: pyroscope/rust_builder_cli:3
   name: make cli/test
 trigger:
   event:

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -1,4 +1,4 @@
-FROM pyroscope/rust_builder_cli:2 as builder
+FROM pyroscope/rust_builder_cli:3 as builder
 
 WORKDIR /app
 ADD pyroscope_backends ./pyroscope_backends

--- a/docker/Dockerfile.cli_builder
+++ b/docker/Dockerfile.cli_builder
@@ -20,7 +20,7 @@ RUN case "${TARGETPLATFORM}" in                       \
 RUN source ./.env  && \
     wget https://static.rust-lang.org/rustup/dist/${RUST_TARGET}/rustup-init && \
     chmod +x rustup-init && \
-    ./rustup-init  -y --default-toolchain=1.64.0 --default-host=${RUST_TARGET}
+    ./rustup-init  -y --default-toolchain=1.76.0 --default-host=${RUST_TARGET}
 ENV PATH=/root/.cargo/bin:$PATH
 
 
@@ -34,9 +34,9 @@ RUN source ./.env && \
      make install
 
 RUN source ./.env && \
-    wget https://zlib.net/zlib-1.2.13.tar.gz && \
-    tar -zxvf zlib-1.2.13.tar.gz && \
-    cd zlib-1.2.13 && \
+    wget https://zlib.net/zlib-1.3.1.tar.gz && \
+    tar -zxvf zlib-1.3.1.tar.gz && \
+    cd zlib-1.3.1 && \
     ./configure --prefix=/usr/local/musl/${RUST_TARGET} && \
     make -j16 && \
     make install

--- a/docker/Dockerfile.manylinux2014_aarch64
+++ b/docker/Dockerfile.manylinux2014_aarch64
@@ -3,7 +3,7 @@ FROM --platform=linux/aarch64 quay.io/pypa/manylinux2014_aarch64
 
 RUN curl https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-musl/rustup-init -o ./rustup-init \
     && chmod +x ./rustup-init \
-    && ./rustup-init  -y --default-toolchain=1.64.0 --default-host=aarch64-unknown-linux-gnu
+    && ./rustup-init  -y --default-toolchain=1.76.0 --default-host=aarch64-unknown-linux-gnu
 ENV PATH=/root/.cargo/bin:$PATH
 RUN yum -y install gcc libffi-devel openssl-devel wget
 

--- a/docker/Dockerfile.manylinux2014_x86_64
+++ b/docker/Dockerfile.manylinux2014_x86_64
@@ -3,7 +3,7 @@ FROM --platform=linux/amd64 quay.io/pypa/manylinux2014_x86_64
 
 RUN curl https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init -o ./rustup-init \
     && chmod +x ./rustup-init \
-    && ./rustup-init  -y --default-toolchain=1.64.0 --default-host=x86_64-unknown-linux-gnu
+    && ./rustup-init  -y --default-toolchain=1.76.0 --default-host=x86_64-unknown-linux-gnu
 ENV PATH=/root/.cargo/bin:$PATH
 RUN yum -y install gcc libffi-devel openssl-devel wget
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,6 @@
 PREFIX ?= pyroscope/rust_builder
-CLI_BUILDER_VERSION ?= 2
-MANYLINUX_VERSION ?= 3
+CLI_BUILDER_VERSION ?= 3
+MANYLINUX_VERSION ?= 4
 
 .PHONY: push_x86_64
 push_x86_64:

--- a/docker/build-container.mk
+++ b/docker/build-container.mk
@@ -34,7 +34,7 @@
 # variable names should be passed through to the container.
 
 USE_CONTAINER       ?= 0
-BUILD_IMAGE_VERSION ?= 2
+BUILD_IMAGE_VERSION ?= 3
 BUILD_IMAGE         ?= pyroscope/rust_builder_cli:$(BUILD_IMAGE_VERSION)
 DOCKER_OPTS         ?= 
 

--- a/pyroscope_ffi/python/scripts/docker.sh
+++ b/pyroscope_ffi/python/scripts/docker.sh
@@ -9,7 +9,7 @@ fi
 
 BUILD_DIR="/work"
 MANYLINUX_PREFIX=pyroscope/rust_builder
-MANYLINUX_VERSION=3
+MANYLINUX_VERSION=4
 
 docker run \
         -w /work/pyroscope_ffi/python \

--- a/pyroscope_ffi/ruby/scripts/docker.sh
+++ b/pyroscope_ffi/ruby/scripts/docker.sh
@@ -9,7 +9,7 @@ fi
 
 BUILD_DIR="/work"
 MANYLINUX_PREFIX=pyroscope/rust_builder
-MANYLINUX_VERSION=3
+MANYLINUX_VERSION=4
 
 docker run \
         -w /work/pyroscope_ffi/ruby/elflib/rbspy \


### PR DESCRIPTION
Fixes CI. Note that the updated build images are to be pushed at [`release`](https://github.com/grafana/pyroscope-rs/blob/f7e864c218d36ee0c6c2e54dbf535c2f881cc77d/.github/workflows/release.yml#L19-L48) – before that CI will be failing, and this is expected