### PR TITLE
fix(ci): pin artifact actions version

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: x64
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: "linux.whl"
           path: "${{github.workspace}}/python"

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.RUBY_VERSION }}
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v2
         with:
           name: "linux.gem"
           path: "${{github.workspace}}/ruby"


### PR DESCRIPTION
In `actions/download-artifact@master` handling of artifact names and paths has changed and is not compatible with the current configuration