### PR TITLE
fix: change to `assert_ne` macro

### DIFF
--- a/src/encode/pprof.rs
+++ b/src/encode/pprof.rs
@@ -30,7 +30,7 @@ impl PProfBuilder {
         if let Some(v) = v {
             return *v;
         }
-        assert!(self.strings.len() != self.profile.string_table.len() + 1);
+        assert_ne!(self.strings.len(), self.profile.string_table.len() + 1);
         let id: i64 = self.strings.len() as i64;
         self.strings.insert(s.to_owned(), id);
         self.profile.string_table.push(s.to_owned());
@@ -42,7 +42,7 @@ impl PProfBuilder {
         if let Some(v) = v {
             return *v;
         }
-        assert!(self.functions.len() != self.profile.function.len() + 1);
+        assert_ne!(self.functions.len(), self.profile.function.len() + 1);
         let id: u64 = self.functions.len() as u64 + 1;
         let f = Function {
             id,
@@ -61,7 +61,7 @@ impl PProfBuilder {
         if let Some(v) = v {
             return *v;
         }
-        assert!(self.locations.len() != self.profile.location.len() + 1);
+        assert_ne!(self.locations.len(), self.profile.location.len() + 1);
         let id: u64 = self.locations.len() as u64 + 1;
         let l = Location {
             id,


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
Changing the `assert` macro to `assert_ne` macro would make it clearer. 

It's an insignificant, minor PR..