### PR TITLE
Update self-hosted runner labels to be more specific

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -53,7 +53,7 @@ jobs:
 
   linux-arm-build:
     name: Linux - arm64
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-arm64
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
   python-release-linux-arm:
     needs: [ 'python-release' ]
     name: Release python linux arm64
-    runs-on: [self-hosted, Linux, ARM64]
+    runs-on: ubuntu-arm64
 
     steps:
       - uses: AutoModality/action-clean@v1
@@ -280,7 +280,7 @@ jobs:
   ruby-release-linux-arm:
     needs: [ 'ruby-release' ]
     name: Release Linux gem arm64
-    runs-on: [ self-hosted, Linux, ARM64 ]
+    runs-on: ubuntu-arm64
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request updates the runner labels on workflows that are running self-hosted runners to use more specific and explicit labels, the current labels can be interpreted wrongly by the system resulting in dev instances picking up jobs for prod instances.

Part of https://github.com/grafana/deployment_tools/issues/142178
Part of https://github.com/grafana/deployment_tools/issues/142917

Related https://github.com/grafana/pyroscope-dotnet/pull/64