### PR TITLE
Draft: Bump CICD actions/upload-artifact

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: [ '3.7', '3.8', '3.9', '3.10', '3.11']
+        PYTHON_VERSION: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     needs: [ 'linux-build' ]
     name: Linux Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build in Docker
         run: make wheel/linux/amd64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "linux.whl"
           path: pyroscope_ffi/python/dist/*
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        PYTHON_VERSION: [ '3.7', '3.8', '3.9', '3.10', '3.11']
     needs: [ 'linux-build' ]
     name: Linux Test
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
       - name: Build in Docker
         run: make wheel/linux/arm64
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "linux-arm.whl"
           path: pyroscope_ffi/python/dist/*
@@ -81,7 +81,7 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "sdist.whl"
           path: pyroscope_ffi/python/dist/*
@@ -117,7 +117,7 @@ jobs:
           python-version: 3.11
 
       - run: make wheel/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: "linux.gem"
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -48,7 +48,7 @@ jobs:
           profile: minimal
           override: true
       - run: make gem/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3
       - run: make wheel/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
@@ -151,7 +151,7 @@ jobs:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3
       - run: make wheel/linux/arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
@@ -197,7 +197,7 @@ jobs:
 
       - run: make pyroscope_ffi/clean wheel/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
@@ -228,7 +228,7 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/python/dist/*
@@ -264,7 +264,7 @@ jobs:
       - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -285,7 +285,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: make gem/linux/arm64
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -328,7 +328,7 @@ jobs:
 
       - run: make pyroscope_ffi/clean gem/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -362,7 +362,7 @@ jobs:
         run: rake source:gem
         working-directory: pyroscope_ffi/ruby
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ github.sha }}
           path: pyroscope_ffi/ruby/pkg/*.gem


### PR DESCRIPTION
Draft - opening to trigger CI flow to assert impact

PR to fix CI and unblock deployments. 

**Issues:**
- `actions/upload-artifact` v2 is deprecated per https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
    - **action:** bump to v4
- py3.12 is now supported due to https://github.com/grafana/pyroscope-rs/pull/181 
   - **action:** add 3.12 to Python testing matrix


Ref:
https://github.com/grafana/pyroscope-rs/pull/181#issuecomment-2489076269
