### PR TITLE
Update pretty_env_logger version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,24 +844,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "humantime 2.1.0",
+ "humantime",
  "is-terminal",
  "log",
  "regex",
@@ -877,7 +864,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime 2.1.0",
+ "humantime",
  "log",
 ]
 
@@ -1277,15 +1264,6 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1614,7 +1592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2200,11 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "pretty_env_logger"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger 0.10.2",
  "log",
 ]
 
@@ -2498,12 +2476,6 @@ dependencies = [
  "pyroscope-rbspy-oncpu",
  "thiserror",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ serde_json = "1.0.115"
 
 [dev-dependencies]
 tokio = { version = "1.18", features = ["full"] }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 assert_matches = "1"
 claims = "0.7.1"
 pyroscope_pprofrs = { path = "pyroscope_backends/pyroscope_pprofrs" }

--- a/pyroscope_cli/Cargo.toml
+++ b/pyroscope_cli/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.64"
 
 [dependencies]
 human-panic = "1.0.3"
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 better-panic = "0.3.0"
 log = "=0.4.17"
 clap_complete = "3.2"

--- a/pyroscope_ffi/python/lib/Cargo.toml
+++ b/pyroscope_ffi/python/lib/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 pyroscope = { path  = "../../../" }
 pyroscope_pyspy = { path = "../../../pyroscope_backends/pyroscope_pyspy" }
 ffikit = { path = "../../ffikit" }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 inferno = "0.11.21"
 log = "0.4"
 

--- a/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
+++ b/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 pyroscope = { path = "../../../../" }
 pyroscope_rbspy = { path = "../../../../pyroscope_backends/pyroscope_rbspy" }
 ffikit = { path = "../../../ffikit" }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = "0.5.0"
 inferno = "0.11.21"
 log = "0.4"
 


### PR DESCRIPTION
Our internal build static analysis tool flagged a few issues with the atty dependency that is pulled by pretty_env_logger 0.4.  Updating the dependency to the latest pretty_env_logger 0.5 drops the atty dependency and will eventually make our internal build happy.

This is a sample warning we are getting:
```
GHSA-g98v-hv3f-hcfr_atty

atty potential unaligned read
**source_type**: lockfile
**package_ecosystem**: crates.io
**vulnerabilitydetails**: On windows, `atty` dereferences a potentially unaligned pointer.

In practice however, the pointer won't be unaligned unless a custom global allocator is used.

In particular, the `System` allocator on windows uses `HeapAlloc`, which guarantees a large enough alignment.

# atty is Unmaintained

A Pull Request with a fix has been provided over a year ago but the maintainer seems to be unreachable.

Last release of `atty` was almost 3 years ago.

## Possible Alternative(s)

The below list has not been vetted in any way and may or may not contain alternatives;

- [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0
- [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0"

**vulnerabilitypackagepurl**: pkg:cargo/atty
```