### PR TITLE
Enable processthreadsapi feature for winapi crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ url = "2.2.2"
 libflate = "1.2.0"
 libc = "^0.2.124"
 prost = "0.11"
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["processthreadsapi"] }
 serde_json = "1.0.115"
 
 [dev-dependencies]


### PR DESCRIPTION
As required by [src/utils.rs:91](https://github.com/grafana/pyroscope-rs/blob/698d30f1ba2f77b492c3e81a88221ec1877cd23d/src/utils.rs#L91)