### PR TITLE
Add OTEL code to the main repo

### DIFF
--- a/pyroscope_ffi/python/README.md
+++ b/pyroscope_ffi/python/README.md
@@ -66,6 +66,26 @@ with pyroscope.tag_wrapper({ "controller": "slow_controller_i_want_to_profile" }
   slow_code()
 ```
 
+### Span profiles support for OpenTelemetry
+Register the `PyroscopeSpanProcessor` in your `OpenTelemetry` integration:
+```python3
+# import span processor
+from pyroscope.otel import PyroscopeSpanProcessor
+
+# obtain a OpenTelemetry tracer provider
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+provider = TracerProvider()
+
+# register the span processor
+provider.add_span_processor(PyroscopeSpanProcessor())
+
+# register the tracer provider
+trace.set_tracer_provider(provider)
+
+# ...
+```
+
 ### Example
 
 Check out this [example python project in our repository](https://github.com/pyroscope-io/pyroscope/tree/main/examples/python) for examples of how you can use these features.

--- a/pyroscope_ffi/python/pyroscope/otel/__init__.py
+++ b/pyroscope_ffi/python/pyroscope/otel/__init__.py
@@ -1,0 +1,40 @@
+import typing
+import threading
+
+from opentelemetry.sdk.trace import (
+    Span,
+    ReadableSpan,
+    SpanProcessor,
+)
+from opentelemetry.context import Context
+
+import pyroscope
+
+PROFILE_ID_SPAN_ATTRIBUTE_KEY = 'pyroscope.profile.id'
+PROFILE_ID_PYROSCOPE_TAG_KEY = 'span_id'
+
+def _is_root_span(span: Span):
+    return span.parent is None or span.parent.is_remote
+
+def _get_span_id(span: Span):
+    return format(span.context.span_id, "016x")
+
+# A span processor that sets a common identifier in spans and profiling samples, so that they can be linked together.
+class PyroscopeSpanProcessor(SpanProcessor):
+
+    def on_start(
+        self, span: Span, parent_context: typing.Optional[Context] = None
+    ) -> None:
+        if _is_root_span(span):
+            span.set_attribute(PROFILE_ID_SPAN_ATTRIBUTE_KEY, format(span.context.span_id, "016x"))
+            pyroscope.add_thread_tag(threading.get_ident(), PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
+
+    def on_end(self, span: ReadableSpan) -> None:
+        if _is_root_span(span):
+            pyroscope.remove_thread_tag(threading.get_ident(), PROFILE_ID_PYROSCOPE_TAG_KEY, _get_span_id(span))
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True

--- a/pyroscope_ffi/python/setup.py
+++ b/pyroscope_ffi/python/setup.py
@@ -38,4 +38,5 @@ setup(
     platforms="any",
     milksnake_tasks=[build_native],
     setup_requires=["pyromilksnakex==0.1.8"],
+    install_requires=["opentelemetry-api>=1.27.0, <2.0.0", "opentelemetry-sdk>=1.27.0, <2.0.0"]
 )


### PR DESCRIPTION
I originally attempted to use the package generated by the [pyroscope-otel project](https://github.com/grafana/otel-profiling-python) but I was unable to import the package into what I was working on. Implementing it like so and using the package that I built after allowed me to import the OTEL code.