### PR TITLE
python: allow lines configuration

### DIFF
--- a/pyroscope_ffi/python/lib/Cargo.toml
+++ b/pyroscope_ffi/python/lib/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+# todo rename this, include python in the name
 name = "pyroscope_ffi"
 version = "0.1.0"
 authors = ["Abid Omar <contact@pyroscope.io>"]

--- a/pyroscope_ffi/python/lib/cbindgen.toml
+++ b/pyroscope_ffi/python/lib/cbindgen.toml
@@ -17,6 +17,11 @@ braces = "SameLine"
 tab_width = 2
 line_length = 80
 
+
 [parse]
 # Do not parse dependent crates
 parse_deps = false
+include = ["LineNoFFI"]
+
+[export]
+include = ["LineNoFFI"]

--- a/pyroscope_ffi/python/lib/include/pyroscope_ffi.h
+++ b/pyroscope_ffi/python/lib/include/pyroscope_ffi.h
@@ -12,6 +12,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef enum {
+  LastInstruction = 0,
+  First = 1,
+  NoLine = 2,
+} LineNo;
+
 bool initialize_logging(uint32_t logging_level);
 
 bool initialize_agent(const char *application_name,
@@ -28,7 +34,8 @@ bool initialize_agent(const char *application_name,
                       bool report_thread_name,
                       const char *tags,
                       const char *tenant_id,
-                      const char *http_headers_json);
+                      const char *http_headers_json,
+                      LineNo line_no);
 
 bool drop_agent(void);
 

--- a/pyroscope_ffi/python/pyroscope/__init__.py
+++ b/pyroscope_ffi/python/pyroscope/__init__.py
@@ -2,10 +2,15 @@ import threading
 import warnings
 import logging
 import json
-from collections import namedtuple
-from pyroscope._native import ffi, lib
-from contextlib import contextmanager 
+from enum import Enum
 
+from pyroscope._native import lib
+from contextlib import contextmanager
+
+class LineNo(Enum):
+    LastInstruction = 0
+    First = 1
+    NoLine = 2
 
 def configure(
         app_name=None,
@@ -26,6 +31,7 @@ def configure(
         tags=None,
         tenant_id="",
         http_headers=None,
+        line_no=LineNo.LastInstruction,
 ):
 
     if app_name is not None:
@@ -56,7 +62,8 @@ def configure(
         tags_to_string(tags).encode("UTF-8"),
         (tenant_id or "").encode("UTF-8"),
         http_headers_to_json(http_headers).encode("UTF-8"),
-)
+        line_no.value
+    )
 
 def shutdown():
     drop = lib.drop_agent()


### PR DESCRIPTION
Helps to workaround https://github.com/grafana/pyroscope-rs/issues/197

Allow disabling the problematic line number collection with 
```python
line_no = pyroscope.LineNo.NoLine
```