### PR TITLE
fix: Update publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
           out-file-path: "dist"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Most likely fixes the python publish issue, as it's due to a newer metadata version.