### PR TITLE
zizmor

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -2,9 +2,12 @@ name: Python Package
 
 on:
   push:
-    branches:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
   linux-build:
@@ -12,11 +15,13 @@ jobs:
     runs-on: ubuntu-latest # TODO try using grafana runners
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Build in Docker
         run: make wheel/linux/amd64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "linux.whl"
           path: pyroscope_ffi/python/dist/*
@@ -36,18 +41,20 @@ jobs:
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
           architecture: x64
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
         with:
           name: "linux.whl"
           path: "${{github.workspace}}/python"
 
       - run: "cd ${{ github.workspace }}/python && ls -l"
       - run: "cd ${{ github.workspace }}/python && pip install *.whl"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: docker run -d -p4040:4040 grafana/pyroscope
       - run: python pyroscope_ffi/python/scripts/tests/test.py
 
@@ -55,12 +62,13 @@ jobs:
     name: Linux - arm64
     runs-on: github-hosted-ubuntu-arm64
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Build in Docker
         run: make wheel/linux/arm64
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "linux-arm.whl"
           path: pyroscope_ffi/python/dist/*
@@ -70,8 +78,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
           python-version: 3.9
       - name: Upgrade pip
@@ -81,7 +91,7 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "sdist.whl"
           path: pyroscope_ffi/python/dist/*
@@ -102,18 +112,20 @@ jobs:
     runs-on: macos-${{ matrix.macos-version }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
           targets: ${{ matrix.target }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
           python-version: 3.11
 
       - run: make wheel/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-python-${{ matrix.target }}
           path: pyroscope_ffi/python/dist/*

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -6,16 +6,20 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     name: Build linux gem amd64
     runs-on: ubuntu-latest
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: "linux.gem"
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -38,16 +42,18 @@ jobs:
       RUST_TARGET: ${{ matrix.target }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: '3.1'
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
           targets: ${{ matrix.target }}
       - run: make gem/mac/${{ matrix.mk-arch }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-ruby-${{ matrix.target }}
           path: pyroscope_ffi/ruby/pkg/*.gem
@@ -63,16 +69,18 @@ jobs:
     name: Linux Test
     runs-on: ubuntu-latest
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: ${{ matrix.RUBY_VERSION }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # 4.3.0
         with:
           name: "linux.gem"
           path: "${{github.workspace}}/ruby"
       - run: "cd ${{ github.workspace }}/ruby && ls -l"
       - run: "cd ${{ github.workspace }}/ruby && gem install *.gem"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Run Ruby Script
         run: pyroscope_ffi/ruby/scripts/tests/test.rb
         env:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     name: Linux build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: rustup toolchain install stable && rustup default stable
       - run: cargo build -p pyroscope-cli
 
@@ -17,5 +22,7 @@ jobs:
     name: Linux build docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make cli/docker-image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,14 +5,19 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish-pyroscope:
     name: pyroscope-lib
     runs-on: ubuntu-latest
     if: "startsWith(github.event.release.tag_name, 'lib-')"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
       - name: publish pyroscope crate
@@ -25,10 +30,10 @@ jobs:
 #    runs-on: ubuntu-latest
 #    if: "startsWith(github.event.release.tag_name, 'cli-')"
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 #        with:
 #          submodules: recursive
-#      - uses: dtolnay/rust-toolchain@v1
+#      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
 #        with:
 #          toolchain: 1.82.0
 #      - name: install libunwind (for pprof)
@@ -43,8 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.event.release.tag_name, 'pprofrs-')"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
       - name: publish pprofrs crate
@@ -58,8 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.event.release.tag_name, 'rbspy-')"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
       - name: publish rbspy crate
@@ -72,8 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.event.release.tag_name, 'pyspy-')"
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
       - name: publish pyspy crate
@@ -86,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.event.release.tag_name, 'python-')"
     steps:
-      - uses: robinraju/release-downloader@v1
+      - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # 1.12
         with: 
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
@@ -95,7 +106,7 @@ jobs:
           out-file-path: "dist"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
@@ -106,7 +117,7 @@ jobs:
     outputs:
       files_json: ${{ steps.list-files.outputs.files_json }}
     steps:
-      - uses: robinraju/release-downloader@v1
+      - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # 1.12
         with:
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
@@ -128,13 +139,13 @@ jobs:
     env:
       GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
     strategy:
-      matrix:
+      matrix: # TODO get rid of list-ruby-gems step
         file: ${{ fromJson(needs.list-ruby-gems.outputs.files_json) }}
     steps:
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: '3.1'
-      - uses: robinraju/release-downloader@v1
+      - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # 1.12
         with: 
           tag: ${{ github.event.release.tag_name }}
           fileName: "*"
@@ -144,4 +155,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           cd dist
-          gem push ${{ matrix.file }}
+          gem push ${GEM_FILE}
+        env:
+          GEM_FILE: ${{ matrix.file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Pre-Release
 
 on: [ push ]
 
+permissions:
+  contents: read
+
 jobs:
   lib-release:
     name: pyroscope-main
@@ -9,40 +12,13 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/lib-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
           title: "pyroscope-${{ github.ref_name }}"
           draft: true
           prerelease: false
-  clibuilder-release:
-    name: clibuilder-release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/clibuilder-')"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - run: docker buildx create --use
-      - run: make -C docker push_cli_builder
-  manylinux-release:
-    name: manylinux-release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/manylinux-')"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
-        name: Login to Docker Hub
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - run: docker buildx create --use
-      - run: make -C docker push_aarch64 push_x86_64
-
   cli-release:
     name: pyroscope-cli
     runs-on: ubuntu-latest
@@ -51,7 +27,7 @@ jobs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
@@ -63,10 +39,10 @@ jobs:
     needs: cli-release
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: recursive
-      - uses: docker/login-action@v3
+          persist-credentials: false
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         name: Login to Docker Hub
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -75,7 +51,7 @@ jobs:
       - run: DOCKER_EXTRA="--output=." make cli/docker-image
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.2
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -89,7 +65,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/pprofrs-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
@@ -102,7 +78,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/rbspy-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
@@ -115,7 +91,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/pyspy-')"
     continue-on-error: true
     steps:
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
@@ -127,16 +103,17 @@ jobs:
     name: Release python linux amd64
     runs-on: ubuntu-latest
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make wheel/linux/amd64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-python-amd64
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -147,16 +124,17 @@ jobs:
     name: Release python linux arm64
     runs-on: github-hosted-ubuntu-arm64
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make wheel/linux/arm64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-python-arm64
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -179,26 +157,28 @@ jobs:
     runs-on: macos-${{ matrix.macos-version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
           target: ${{ matrix.target }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
           python-version: 3.11
 
       - run: make pyroscope_ffi/clean wheel/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-python-macos-${{ matrix.target }}
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -210,10 +190,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
           python-version: 3.9
       - name: Upgrade pip
@@ -223,13 +204,13 @@ jobs:
         run: python setup.py sdist
         working-directory: pyroscope_ffi/python
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-python-sdist
           path: pyroscope_ffi/python/dist/*
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -244,7 +225,7 @@ jobs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"
@@ -256,16 +237,17 @@ jobs:
     name: Release Linux gem amd64
     runs-on: ubuntu-latest
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make gem/linux/amd64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-ruby-amd64
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -277,15 +259,17 @@ jobs:
     name: Release Linux gem arm64
     runs-on: github-hosted-ubuntu-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: make gem/linux/arm64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-ruby-arm64
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -309,24 +293,26 @@ jobs:
     runs-on: macos-${{ matrix.macos-version }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: '3.1'
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
           toolchain: 1.85.0
           target: ${{ matrix.target }}
 
       - run: make pyroscope_ffi/clean gem/mac/${{ matrix.mk-arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-ruby-mac-${{ matrix.target }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -339,10 +325,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: AutoModality/action-clean@v1
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@dffc446db9ba5a0c4446edb5bca1c5c473a806c5 # v1.235.0
         with:
           ruby-version: '3.1'
 
@@ -354,13 +341,13 @@ jobs:
         run: rake source:gem
         working-directory: pyroscope_ffi/ruby
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ github.sha }}-ruby-source
           path: pyroscope_ffi/ruby/pkg/*.gem
 
       - name: Upload release artifact
-        uses: korniltsev/actions-upload-release-asset@v1
+        uses: korniltsev/actions-upload-release-asset@a7f1a48a96ff80f206fd26bdbfcf81539d44fa5e # TODO(korniltsev): get rid of this fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -376,7 +363,7 @@ jobs:
       upload_url: ${{ steps.auto-release.outputs.upload_url }}
     steps:
       - id: auto-release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: "marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0" # v1.2.1 TODO(korniltsev): get rid of this, this one is unmaintained
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.ref_name }}"


### PR DESCRIPTION
```
~/p/pyroscope-rs (zizmor) > zizmor --gh-token=$(gh auth token) ./.github/
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci-ffi-python.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci-ffi-ruby.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/cli.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release.yml
info[use-trusted-publishing]: prefer trusted publishing for authentication
   --> ./.github/workflows/publish.yml:109:9
    |
109 |         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
    |         -------------------------------------------------------------------------- info: this step
110 |         with:
111 |           user: __token__
112 |           password: ${{ secrets.PYPI_API_TOKEN }}
    |           --------------------------------------- info: uses a manually-configured credential instead of Trusted Publishing
    |
    = note: audit confidence → High

1 finding: 0 unknown, 1 informational, 0 low, 0 medium, 0 high
```

Only one item left which I will not address in this PR 