### PR TITLE
Update Ruby publish workflow to use Vault for secrets

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   push-ruby-gems:
@@ -16,6 +17,11 @@ jobs:
     outputs:
       files_json: ${{ steps.list-files.outputs.files_json }}
     steps:
+      - name: Get secrets from Vault
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            RUBYGEMS_API_KEY=publishing:rubygems_api_key
       - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # 1.12
         with:
           tag: ${{ github.event.release.tag_name }}
@@ -37,6 +43,6 @@ jobs:
             sleep 5;
           done
         env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          GEM_HOST_API_KEY: ${{ env.RUBYGEMS_API_KEY }}
 
 


### PR DESCRIPTION
## Summary
- Replace hardcoded GitHub secret `RUBYGEMS_API_KEY` with Vault integration
- Add Vault secrets retrieval step using `grafana/shared-workflows/actions/get-vault-secrets`
- Update environment variable reference from `secrets.RUBYGEMS_API_KEY` to `env.RUBYGEMS_API_KEY`

This follows the same pattern used in the [pyroscope-java repository](https://github.com/grafana/pyroscope-java/blob/main/.github/workflows/release.yml) for managing sensitive credentials through Vault.

## Test plan
- [ ] Verify the Vault path `publishing:rubygems_api_key` exists and contains the correct API key
- [ ] Test the workflow on the next Ruby gem release

🤖 Generated with [Claude Code](https://claude.ai/code)