### PR TITLE
Bump prost to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,35 +2071,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2163,7 +2140,7 @@ dependencies = [
  "log",
  "names",
  "pretty_env_logger",
- "prost 0.13.5",
+ "prost",
  "pyroscope_pprofrs",
  "reqwest",
  "serde_json",
@@ -2363,7 +2340,7 @@ dependencies = [
  "memmap2 0.9.8",
  "nix 0.30.1",
  "proc-maps",
- "prost 0.14.1",
+ "prost",
  "rand 0.9.2",
  "rbspy-ruby-structs",
  "remoteprocess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ reqwest = { version = "0.12", features = ["blocking"], default-features = false 
 url = "2.2.2"
 libflate = "2.1.0"
 libc = "^0.2.124"
-prost = "0.13"
+prost = "0.14"
 winapi = "0.3.9"
 serde_json = "1.0.115"
 


### PR DESCRIPTION
This is the last prost release and we'd love to be able to not compile 2 different versions.
Since we've upgraded tonic and prost, it would be awesome if we could also bump the dependency in pyroscope-rs :)

Fixes https://github.com/grafana/pyroscope-rs/issues/255
