### PR TITLE
chore: remove std::ops::Add from Stacktrace

### DIFF
--- a/pyroscope_backends/pyroscope_pprofrs/src/lib.rs
+++ b/pyroscope_backends/pyroscope_pprofrs/src/lib.rs
@@ -157,7 +157,7 @@ impl Pprof<'_> {
             .data
             .iter()
             .map(|(stacktrace, ss)| {
-                let stacktrace = stacktrace.to_owned() + &self.ruleset;
+                let stacktrace = stacktrace.to_owned().add_tag_rules(&self.ruleset);
                 (stacktrace, ss.to_owned())
             })
             .collect();

--- a/pyroscope_ffi/python/lib/src/backend.rs
+++ b/pyroscope_ffi/python/lib/src/backend.rs
@@ -115,7 +115,7 @@ impl Backend for Pyspy {
                     let own_trace: StackTrace =
                         Into::<StackTraceWrapper>::into((trace.clone(), &backend_config)).into();
 
-                    let stacktrace = own_trace + &ruleset.lock()?.clone();
+                    let stacktrace = own_trace.add_tag_rules(&*ruleset.lock()?);
 
                     buffer.lock()?.record(stacktrace)?;
                 }

--- a/pyroscope_ffi/ruby/ext/rbspy/src/backend.rs
+++ b/pyroscope_ffi/ruby/ext/rbspy/src/backend.rs
@@ -128,7 +128,7 @@ impl Backend for Rbspy {
                 let own_trace: StackTrace =
                     Into::<StackTraceWrapper>::into((stack_trace, &backend_config)).into();
 
-                let stacktrace = own_trace + &ruleset;
+                let stacktrace = own_trace.add_tag_rules(&ruleset);
 
                 buffer.lock()?.record(stacktrace)?;
             }

--- a/src/backend/ruleset.rs
+++ b/src/backend/ruleset.rs
@@ -68,9 +68,8 @@ impl Ruleset {
     }
 }
 
-impl std::ops::Add<&Ruleset> for StackTrace {
-    type Output = Self;
-    fn add(self, other: &Ruleset) -> Self {
+impl StackTrace {
+   pub fn add_tag_rules(self, other: &Ruleset) -> Self {
         // Get global Tags
         let global_tags: Vec<Tag> = other.get_global_tags().unwrap_or_default();
 

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -335,7 +335,7 @@ fn test_stacktrace_add() {
     assert_eq!(stacktrace.metadata, initial_metadata);
 
     // Add the Stacktrace to the Ruleset
-    let applied_stacktrace = stacktrace + &ruleset;
+    let applied_stacktrace = stacktrace.add_tag_rules(&ruleset);
 
     initial_metadata.add_tag(Tag::new("key1".to_string(), "value".to_string()));
     initial_metadata.add_tag(Tag::new("key2".to_string(), "value".to_string()));


### PR DESCRIPTION
Replace std::ops::Add with `add_tag_rules` function
Also remove unnecessary cloning of rule-set in python
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
