### PR TITLE
ruleset: optimize

### DIFF
--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -442,35 +442,3 @@ fn test_stackbuffer_clear() {
     buffer.clear();
     assert_eq!(buffer.data.len(), 0);
 }
-
-#[bench]
-fn bench(b: &mut test::Bencher) {
-    let ruleset = Ruleset::new();
-
-    ruleset
-        .add_rule(Rule::ThreadTag(
-            tid(55),
-            Tag::new("keyA".to_string(), "valueA".to_string()),
-        ))
-        .unwrap();
-
-    ruleset
-        .add_rule(Rule::ThreadTag(
-            tid(55),
-            Tag::new("keyB".to_string(), "valueB".to_string()),
-        ))
-        .unwrap();
-
-
-
-    b.iter(||{
-        let stacktrace = StackTrace{
-            pid: None,
-            thread_id: Some(tid(55)),
-            thread_name: None,
-            frames: vec![],
-            metadata: Default::default(),
-        };
-        let _ = stacktrace.add_tag_rules(&ruleset);
-    })
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,6 @@
 //! agent_ready.shutdown();
 //! ```
 
-#![feature(test)]
-extern crate test;
-
 extern crate core;
 
 // Re-exports structs


### PR DESCRIPTION
```
before
99.49873466257668 ns/iter (+/- 3.8137934560327267)
after
63.307363925137366 ns/iter (+/- 1.058291552197801)
```
Aint much but honest work.jpeg


Idk how to commit the bench so just paste it here 
```
#[bench]
fn bench(b: &mut test::Bencher) {
    let ruleset = Ruleset::new();

    ruleset
        .add_rule(Rule::ThreadTag(
            tid(55),
            Tag::new("keyA".to_string(), "valueA".to_string()),
        ))
        .unwrap();

    ruleset
        .add_rule(Rule::ThreadTag(
            tid(55),
            Tag::new("keyB".to_string(), "valueB".to_string()),
        ))
        .unwrap();



    b.iter(||{
        let stacktrace = StackTrace{
            pid: None,
            thread_id: Some(tid(55)),
            thread_name: None,
            frames: vec![],
            metadata: Default::default(),
        };
        let _ = stacktrace.add_tag_rules(&ruleset);
    })
}

```