### PR TITLE
Split Rust CI tests into concurrent package matrix

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -27,8 +27,16 @@ jobs:
         run: make rust/fmt/check
 
   test:
-    name: cargo test
+    name: cargo test (${{ matrix.package }})
     runs-on: ubuntu-x64-small
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - pyroscope
+          - ffikit
+          - pyroscope_ffi
+          - ffiruby
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -39,4 +47,4 @@ jobs:
           toolchain: stable
 
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test -p ${{ matrix.package }}


### PR DESCRIPTION
### Motivation
- Reduce CI wall-clock time by running Rust tests concurrently across individual workspace packages instead of a single slow `cargo test --workspace` job.
- Prevent a single package failure from canceling other package test jobs by disabling fast-fail semantics.

### Description
- Updated `.github/workflows/ci-rust.yml` `test` job to use a matrix over packages so the job runs once per package.
- Added `strategy` with `fail-fast: false` and a `package` matrix: `pyroscope`, `ffikit`, `pyroscope_ffi`, and `ffiruby`.
- Changed the test invocation from `cargo test --workspace` to `cargo test -p ${{ matrix.package }}`.
- Updated the job name to include the package via `name: cargo test (${{ matrix.package }})` for clearer logs.

### Testing
- Verified the workflow diff with `git diff -- .github/workflows/ci-rust.yml` which showed the intended matrix and command changes.
- Printed the updated workflow with `nl -ba .github/workflows/ci-rust.yml | sed -n '1,120p'` to confirm the matrix, `fail-fast: false`, and the `cargo test -p` invocation were present.
- Committed the changes with `git commit` and observed a successful commit without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dbf321ae88320a4ba7a461e2b3a64)