### PR TITLE
Ensure Python wheels build stripped shared libs with release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ codegen-units = 4
 [profile.release]
 opt-level=3
 debug = false
+strip = "symbols"
 rpath = false
 lto = true
 debug-assertions = false

--- a/pyroscope_ffi/python/setup.py
+++ b/pyroscope_ffi/python/setup.py
@@ -10,7 +10,7 @@ LIB_DIR = str(SCRIPT_DIR / "lib")
 def build_native(spec):
     # Step 1: build the rust library
     build = spec.add_external_build(
-        cmd=['cargo', 'build', '-p' 'pyroscope_ffi', '--release'],
+        cmd=['cargo', 'build', '--package', 'pyroscope_ffi', '--profile', 'release'],
         path=LIB_DIR
     )
 


### PR DESCRIPTION
### Motivation
- Ensure shared libraries bundled into the Python wheel are built with optimizations and have debug symbols stripped to reduce size and match release expectations for FFI artifacts.

### Description
- Add `strip = "symbols"` to the workspace `[profile.release]` in `Cargo.toml` so release-built shared libraries are stripped by default.
- Update the Python wheel native build invocation in `pyroscope_ffi/python/setup.py` to use `cargo build --package pyroscope_ffi --profile release` so the build explicitly uses the release profile and the package flag.

### Testing
- Ran `python -m py_compile pyroscope_ffi/python/setup.py`, which succeeded.
- Attempted `cargo check -p pyroscope_ffi --profile release`, which failed due to crates.io network/proxy errors (HTTP 403) in this environment and is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dc157fab88320b86a84cb1315ae02)