### PR TITLE
ci: use main-only push trigger for ruby ffi workflow

### DIFF
--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -2,7 +2,7 @@ name: Ruby Package
 
 on:
   push:
-    branches:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -91,4 +91,3 @@ jobs:
           PYROSCOPE_API_TOKEN: ${{ secrets.PYROSCOPE_API_TOKEN }}
           PYROSCOPE_ONCPU: ${{ matrix.PYROSCOPE_ONCPU }}
           RUBY_VERSION: ${{ matrix.RUBY_VERSION }}
-


### PR DESCRIPTION
### Motivation
- Restrict the Ruby FFI workflow to only run on pushes to `main` so tag pushes (including `python-*` tags) do not trigger it and to address review feedback preferring a branch filter over `tags-ignore`.

### Description
- Updated `.github/workflows/ci-ffi-ruby.yml` to replace the `push.tags-ignore` configuration with `push.branches: [main]` so only pushes to `main` match the `push` event.

### Testing
- Verified the workflow trigger via `sed -n '1,20p' .github/workflows/ci-ffi-ruby.yml` and `nl -ba .github/workflows/ci-ffi-ruby.yml | sed -n '1,15p'`, both showing `on.push.branches: [main]` (commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dceb5c2708320a425e7f59fa09290)