### PR TITLE
Fix Ruby test Pyroscope CLI flag name

### DIFF
--- a/pyroscope_ffi/ruby/scripts/tests/test.rb
+++ b/pyroscope_ffi/ruby/scripts/tests/test.rb
@@ -8,14 +8,12 @@ puts RUBY_VERSION
 
 def start_local_pyroscope
   container_name = "pyroscope-ruby-test-#{Process.pid}"
-
   system(
     "docker", "run", "-d",
     "--name", container_name,
     "-p", "4040:4040",
     "grafana/pyroscope:latest",
-    "server",
-    "-ingester.ring.min-ready-duration=0s"
+    "-ingester.min-ready-duration=0s"
   )
 
   unless $?.success?


### PR DESCRIPTION
### Motivation
- Fix CI flakiness by passing the correct Pyroscope CLI flag because the previous flag path was not recognized and had no effect.

### Description
- Update `pyroscope_ffi/ruby/scripts/tests/test.rb` to start the Pyroscope container with `-ingester.min-ready-duration=0s` and remove the obsolete `server` argument.
- Keep the readiness polling loop as a fixed `20.times` wait and avoid further behavioral changes to the script.

### Testing
- Attempted to run `ruby -c pyroscope_ffi/ruby/scripts/tests/test.rb` to validate syntax but it failed due to missing Ruby runtime (`bash: command not found: ruby`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dca65cb688320b146515509ba9978)