### PR TITLE
ci: add Ruby 3.4.6 to ffi ruby test matrix

### DIFF
--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         PYROSCOPE_ONCPU: [1, 0]
-        RUBY_VERSION: ['3.1', '3.2', '3.3', '3.3.8', '3.4.3']
+        RUBY_VERSION: ['3.1', '3.2', '3.3', '3.3.8', '3.4.3', '3.4.6']
     needs: ['linux-build']
     name: Linux Test
     runs-on: ubuntu-x64-large


### PR DESCRIPTION
### Motivation
- Expand CI coverage to include the latest Ruby 3.4 patch release for the Ruby FFI test job.

### Description
- Add `3.4.6` to the `RUBY_VERSION` matrix in `.github/workflows/ci-ffi-ruby.yml` for the `linux-test` job.

### Testing
- Ran `git diff --check` and `git status --short` to validate the change and both reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991b0bedc4c8320a5e62ce1ddc2ee5d)