### PR TITLE
Use Cargo package version for spy version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ffiruby"
-version = "0.0.1"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cbindgen",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "pyroscope_python_extension"
-version = "0.0.1"
+version = "1.0.1"
 dependencies = [
  "cbindgen",
  "libc",

--- a/ci/bump_ffi_version.sh
+++ b/ci/bump_ffi_version.sh
@@ -44,19 +44,15 @@ case "$lang" in
     ruby_current="$(sed -n "s/.*VERSION = '\([0-9]*\.[0-9]*\.[0-9]*\)'.*/\1/p" pyroscope_ffi/ruby/lib/pyroscope/version.rb)"
     ruby_new="$(bump_semver "$ruby_current")"
     sed -i -E "s/(VERSION = ')[0-9]+\.[0-9]+\.[0-9]+('\\.freeze)/\1$ruby_new\2/" pyroscope_ffi/ruby/lib/pyroscope/version.rb
-    sed -i -E "s/^(const RBSPY_VERSION: &str = \"?)[0-9]+\.[0-9]+\.[0-9]+(\";)/\1$ruby_new\2/" pyroscope_ffi/ruby/ext/rbspy/src/lib.rs
-    sed -i -E '0,/^version = "[0-9]+\.[0-9]+\.[0-9]+"/s//version = "0.0.1"/' pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
-    echo "Ruby versions bumped: gem/rust const $ruby_current -> $ruby_new"
-    echo "Ruby Cargo package version pinned to 0.0.1"
+    sed -i -E "0,/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/s//version = \"$ruby_new\"/" pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
+    echo "Ruby versions bumped: gem/rust cargo $ruby_current -> $ruby_new"
     ;;
   python)
     python_current="$(sed -n 's/^version = "\([0-9]*\.[0-9]*\.[0-9]*\)"/\1/p' pyproject.toml)"
     python_new="$(bump_semver "$python_current")"
     sed -i -E "s/^(version = \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1$python_new\2/" pyproject.toml
-    sed -i -E "s/^(const PYSPY_VERSION: &str = \"?)[0-9]+\.[0-9]+\.[0-9]+(\";)/\1$python_new\2/" pyroscope_ffi/python/rust/src/lib.rs
-    sed -i -E '0,/^version = "[0-9]+\.[0-9]+\.[0-9]+"/s//version = "0.0.1"/' pyroscope_ffi/python/rust/Cargo.toml
-    echo "Python versions bumped: package/rust const $python_current -> $python_new"
-    echo "Python Cargo package version pinned to 0.0.1"
+    sed -i -E "0,/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/s//version = \"$python_new\"/" pyroscope_ffi/python/rust/Cargo.toml
+    echo "Python versions bumped: package/rust cargo $python_current -> $python_new"
     ;;
   *)
     echo "Invalid language '$lang'. Use ruby or python." >&2

--- a/ci/check-spy-versions.sh
+++ b/ci/check-spy-versions.sh
@@ -6,8 +6,8 @@ cd "$(dirname "$0")/.."
 py_cfg_version=$(awk -F'=' '/^version[[:space:]]*=/{gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyproject.toml)
 rb_version=$(sed -nE "s/.*VERSION = '([^']+)'.*/\1/p" pyroscope_ffi/ruby/lib/pyroscope/version.rb)
 
-py_rust_version=$(sed -nE 's/^const PYSPY_VERSION: &str = "([^"]+)";/\1/p' pyroscope_ffi/python/rust/src/lib.rs)
-rb_rust_version=$(sed -nE 's/^const RBSPY_VERSION: &str = "([^"]+)";/\1/p' pyroscope_ffi/ruby/ext/rbspy/src/lib.rs)
+py_rust_version=$(awk -F'=' '/^version[[:space:]]*=/{gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyroscope_ffi/python/rust/Cargo.toml)
+rb_rust_version=$(awk -F'=' '/^version[[:space:]]*=/{gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyroscope_ffi/ruby/ext/rbspy/Cargo.toml)
 
 if [[ -z "$py_cfg_version" || -z "$rb_version" || -z "$py_rust_version" || -z "$rb_rust_version" ]]; then
   echo "failed to read one or more version values"
@@ -15,12 +15,12 @@ if [[ -z "$py_cfg_version" || -z "$rb_version" || -z "$py_rust_version" || -z "$
 fi
 
 if [[ "$py_cfg_version" != "$py_rust_version" ]]; then
-  echo "pyspy version mismatch: setup.cfg=$py_cfg_version rust=$py_rust_version"
+  echo "pyspy version mismatch: pyproject.toml=$py_cfg_version cargo=$py_rust_version"
   exit 1
 fi
 
 if [[ "$rb_version" != "$rb_rust_version" ]]; then
-  echo "rbspy version mismatch: version.rb=$rb_version rust=$rb_rust_version"
+  echo "rbspy version mismatch: version.rb=$rb_version cargo=$rb_rust_version"
   exit 1
 fi
 

--- a/pyroscope_ffi/python/rust/Cargo.toml
+++ b/pyroscope_ffi/python/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pyroscope_python_extension" # This is used as package name for so placement
 # todo figure out how to put this into pyroscope package without renaming the main crate
-version = "0.0.1"
+version = "1.0.1"
 authors = [
     "Tolyan Korniltsev <anatoly.korniltsev@grafana.com>"
 ]

--- a/pyroscope_ffi/python/rust/src/lib.rs
+++ b/pyroscope_ffi/python/rust/src/lib.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_char;
 
 const LOG_TAG: &str = "Pyroscope::pyspy::ffi";
 const PYSPY_NAME: &str = "pyspy";
-const PYSPY_VERSION: &str = "1.0.1";
+const PYSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[no_mangle]
 pub extern "C" fn initialize_logging(logging_level: u32) -> bool {

--- a/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
+++ b/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffiruby"
-version = "0.0.1"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.64"
 

--- a/pyroscope_ffi/ruby/ext/rbspy/src/lib.rs
+++ b/pyroscope_ffi/ruby/ext/rbspy/src/lib.rs
@@ -13,7 +13,7 @@ use pyroscope::pyroscope::PyroscopeAgentBuilder;
 
 const LOG_TAG: &str = "Pyroscope::rbspy::ffi";
 const RBSPY_NAME: &str = "rbspy";
-const RBSPY_VERSION: &str = "1.0.1";
+const RBSPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn transform_report(report: Report) -> Report {
     let cwd = env::current_dir().unwrap();

--- a/src/pyroscope.rs
+++ b/src/pyroscope.rs
@@ -20,6 +20,8 @@ use crate::{
 use crate::backend::{BackendImpl, ThreadTag};
 
 const LOG_TAG: &str = "Pyroscope::Agent";
+const PPROFRS_SPY_NAME: &str = "pyroscope-rs";
+const PPROFRS_SPY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Pyroscope Agent Configuration. This is the configuration that is passed to the agent.
 ///
@@ -65,8 +67,8 @@ impl Default for PyroscopeConfig {
                 .replace('-', "."),
             tags: HashMap::new(),
             sample_rate: 100u32,
-            spy_name: "undefined".to_string(),
-            spy_version: "unknown".to_string(),
+            spy_name: PPROFRS_SPY_NAME.to_string(),
+            spy_version: PPROFRS_SPY_VERSION.to_string(),
             basic_auth: None,
             func: None,
             tenant_id: None,


### PR DESCRIPTION
### Motivation
- Ensure the built-in pprof-rs backend advertises a concrete spy identity and version sourced from the crate metadata instead of hardcoded `undefined`/`unknown` values.
- Keep the pprof-rs default spy version tied to the package `CARGO_PKG_VERSION` so it follows crate releases without extra bump/sync logic.

### Description
- Added `PPROFRS_SPY_NAME` (`"pyroscope-rs"`) and `PPROFRS_SPY_VERSION` (using `env!("CARGO_PKG_VERSION")`) constants in `src/pyroscope.rs` and switched `PyroscopeConfig::default()` to use them for `spy_name` and `spy_version`.
- Switched Python and Ruby FFI Rust entrypoints to read their crate version via `env!("CARGO_PKG_VERSION")` (`pyroscope_ffi/python/rust/src/lib.rs` and `pyroscope_ffi/ruby/ext/rbspy/src/lib.rs`).
- Bumped the FFI crate `version` fields to `1.0.1` in `pyroscope_ffi/python/rust/Cargo.toml` and `pyroscope_ffi/ruby/ext/rbspy/Cargo.toml` and updated `Cargo.lock` accordingly.
- Updated CI helper scripts: `ci/bump_ffi_version.sh` now updates the FFI crates' `Cargo.toml` versions (instead of editing source constants) and `ci/check-spy-versions.sh` reads FFI versions from those `Cargo.toml` files and adjusted its mismatch messages.

### Testing
- Ran `cargo test --tests`, and all unit and integration tests completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6991e70ba1248320a0bbb9cd4f362c44)