### PR TITLE
Add musllinux Python wheel build and release automation

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -93,6 +93,37 @@ jobs:
           name: "linux-arm.whl"
           path: dist/*
 
+  linux-musllinux-build:
+    name: musllinux - amd64
+    runs-on: ubuntu-x64-large
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: make wheel/musllinux/amd64
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: "musllinux.whl"
+          path: dist/*
+
+  linux-musllinux-arm-build:
+    name: musllinux - arm64
+    runs-on: ubuntu-arm64-large
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: make wheel/musllinux/arm64
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: "musllinux-arm.whl"
+          path: dist/*
+
   sdist-build:
     name: sdist
     runs-on: ubuntu-x64-small

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -48,6 +48,50 @@ jobs:
         with:
           draft: true
           files: dist/pyroscope*.whl
+
+  python-release-musllinux:
+    permissions:
+      contents: write
+    needs: [ 'python-release' ]
+    name: Release python musllinux amd64
+    runs-on: ubuntu-x64-large
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make wheel/musllinux/amd64
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.sha }}-python-musllinux-amd64
+          path: dist/*
+
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          draft: true
+          files: dist/pyroscope*.whl
+
+  python-release-musllinux-arm:
+    permissions:
+      contents: write
+    needs: [ 'python-release' ]
+    name: Release python musllinux arm64
+    runs-on: ubuntu-arm64-large
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: make wheel/musllinux/arm64
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: ${{ github.sha }}-python-musllinux-arm64
+          path: dist/*
+
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          draft: true
+          files: dist/pyroscope*.whl
   python-release-macos:
     permissions:
       contents: write

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+ARG PLATFORM=x86_64
+FROM quay.io/pypa/musllinux_1_2_${PLATFORM} AS builder
+
+RUN apk add --no-cache curl gcc libffi-dev make musl-dev
+
+RUN adduser -D -h /home/builder builder \
+    && mkdir -p /pyroscope-rs \
+    && chown builder:builder /pyroscope-rs
+
+USER builder
+RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
+
+ENV RUST_VERSION=1.87
+RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \
+    && rm /tmp/rustup-init
+ENV PATH=/home/builder/.cargo/bin:$PATH
+
+WORKDIR /pyroscope-rs
+
+RUN /opt/python/cp39-cp39/bin/python -m pip install --user build
+
+ADD --chown=builder:builder pyproject.toml \
+    rustfmt.toml \
+    Cargo.toml \
+    Cargo.lock \
+    ./
+
+ADD --chown=builder:builder src src
+ADD --chown=builder:builder pyroscope_ffi/ pyroscope_ffi/
+
+RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \
+    /opt/python/cp39-cp39/bin/python -m build --wheel
+
+FROM scratch
+COPY --from=builder /pyroscope-rs/dist dist/

--- a/ffi.mk
+++ b/ffi.mk
@@ -22,6 +22,24 @@ wheel/linux/arm64:
 	 	-f docker/wheel.Dockerfile \
 	 	.
 
+.phony: wheel/musllinux/amd64
+wheel/musllinux/amd64:
+	docker buildx build \
+		--build-arg=PLATFORM=x86_64 \
+		--platform=linux/amd64 \
+		--output=. \
+		-f docker/wheel-musllinux.Dockerfile \
+		.
+
+.phony: wheel/musllinux/arm64
+wheel/musllinux/arm64:
+	docker buildx build \
+		--build-arg=PLATFORM=aarch64 \
+		--platform=linux/arm64 \
+		--output=. \
+		-f docker/wheel-musllinux.Dockerfile \
+		.
+
 .phony: wheel/mac/amd64
 wheel/mac/amd64:
 	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=x86_64-apple-darwin python -m build --wheel


### PR DESCRIPTION
### Motivation

- Provide musl-based Python wheels (musllinux) in addition to existing manylinux wheels so the package can be used on musl-based Linux distributions. 
- Integrate musllinux wheel builds into CI and the release process so musllinux artifacts are produced, uploaded, and attached to draft releases automatically.

### Description

- Add a new Docker build image at `docker/wheel-musllinux.Dockerfile` which builds wheels on `quay.io/pypa/musllinux_1_2_${PLATFORM}` using the musl Rust host toolchain. 
- Add Make targets `wheel/musllinux/amd64` and `wheel/musllinux/arm64` in `ffi.mk` to invoke the musllinux Docker builds the same way as existing Linux wheel targets. 
- Extend CI workflow ` .github/workflows/ci-ffi-python.yml` with jobs `linux-musllinux-build` and `linux-musllinux-arm-build` to build and upload musllinux wheel artifacts for amd64 and arm64. 
- Extend release workflow ` .github/workflows/release-python.yml` with jobs `python-release-musllinux` and `python-release-musllinux-arm` to build musllinux wheels during a python-* release and attach them to the draft GitHub release.

### Testing

- Ran `make -n wheel/musllinux/amd64` and `make -n wheel/musllinux/arm64` to validate the Makefile targets, both succeeded (dry-run showed expected `docker buildx build` commands). 
- Ran `git diff --check` and fixed whitespace issues; the repository shows the changes staged and committed. 
- Attempted YAML parsing validation and `pyyaml` install, but external package install/validation was blocked in this environment (network/proxy constraints), so full YAML schema validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6997e12f9b4c83208c0f5a2d1698be58)