### PR TITLE
Fix: Add musllinux (Alpine Linux) support for Python wheels

### DIFF
--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.4
+ARG PLATFORM=x86_64
+FROM quay.io/pypa/musllinux_1_2_${PLATFORM} AS builder
+
+RUN apk add --no-cache gcc musl-dev libffi-dev make
+
+RUN adduser -D builder \
+    && mkdir -p /pyroscope-rs \
+    && chown builder:builder /pyroscope-rs
+
+USER builder
+RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
+
+ENV RUST_VERSION=1.87
+RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \
+    && rm /tmp/rustup-init
+ENV PATH=/home/builder/.cargo/bin:$PATH
+
+WORKDIR /pyroscope-rs
+
+RUN /opt/python/cp39-cp39/bin/python -m pip install --user build
+
+ADD --chown=builder:builder pyproject.toml \
+    rustfmt.toml \
+    Cargo.toml \
+    Cargo.lock \
+    ./
+
+ADD --chown=builder:builder src src
+ADD --chown=builder:builder pyroscope_ffi/ pyroscope_ffi/
+
+RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
+    --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \
+    /opt/python/cp39-cp39/bin/python -m build --wheel
+
+USER root
+RUN auditwheel repair dist/*.whl --wheel-dir dist-repaired/
+
+FROM scratch
+COPY --from=builder  /pyroscope-rs/dist-repaired dist/

--- a/ffi.mk
+++ b/ffi.mk
@@ -22,6 +22,24 @@ wheel/linux/arm64:
 	 	-f docker/wheel.Dockerfile \
 	 	.
 
+.phony: wheel/musllinux/amd64
+wheel/musllinux/amd64:
+	docker buildx build \
+		--build-arg=PLATFORM=x86_64 \
+	 	--platform=linux/amd64 \
+	 	--output=. \
+	 	-f docker/wheel-musllinux.Dockerfile \
+	 	.
+
+.phony: wheel/musllinux/arm64
+wheel/musllinux/arm64:
+	docker buildx build \
+		--build-arg=PLATFORM=aarch64 \
+	 	--platform=linux/arm64 \
+	 	--output=. \
+	 	-f docker/wheel-musllinux.Dockerfile \
+	 	.
+
 .phony: wheel/mac/amd64
 wheel/mac/amd64:
 	MACOSX_DEPLOYMENT_TARGET=11.0 CARGO_BUILD_TARGET=x86_64-apple-darwin python -m build --wheel

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,6 +29,11 @@ pub struct ThreadId {
     pthread: libc::pthread_t,
 }
 
+// SAFETY: pthread_t is an opaque thread identifier used as a handle,
+// never dereferenced. On musl it's *mut c_void, on glibc it's c_ulong.
+unsafe impl Send for ThreadId {}
+unsafe impl Sync for ThreadId {}
+
 impl From<libc::pthread_t> for ThreadId {
     fn from(value: libc::pthread_t) -> Self {
         Self { pthread: value }
@@ -42,7 +47,7 @@ impl ThreadId {
     }
 
     pub fn to_string(&self) -> String {
-        self.pthread.to_string()
+        (self.pthread as usize).to_string()
     }
 }
 


### PR DESCRIPTION
Fix pthread_t portability issue where musl defines it as *mut c_void (lacking Send/Sync/Display) vs glibc's c_ulong. Add musllinux Dockerfile and Makefile targets for building wheels.

Fixes #209