### PR TITLE
Use static vendored OpenSSL in Python and Ruby Docker builds (Vibe Kanban)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1866,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ claims = "=0.8.0"
 default = ["rustls-tls"]
 rustls-tls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
+native-tls-vendored = ["reqwest/native-tls-vendored"]
 rustls-no-provider = ["reqwest/rustls-no-provider"]
 backend-pprof-rs = ["dep:pprof"]
 

--- a/docker/gem.Dockerfile
+++ b/docker/gem.Dockerfile
@@ -6,7 +6,7 @@ RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rus
     && chmod +x ./rustup-init \
     && ./rustup-init  -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu
 ENV PATH=/root/.cargo/bin:$PATH
-RUN yum -y install gcc libffi-devel openssl-devel wget gcc-c++ glibc-devel make
+RUN yum -y install gcc libffi-devel perl-core wget gcc-c++ glibc-devel make
 
 WORKDIR /pyroscope-rs
 
@@ -18,7 +18,7 @@ ADD rustfmt.toml \
 ADD src src
 ADD pyroscope_ffi/ pyroscope_ffi/
 # TODO --frozen
-RUN --mount=type=cache,target=/root/.cargo/registry cargo build -p ffiruby --release
+RUN --mount=type=cache,target=/root/.cargo/registry cargo build -p ffiruby --release --no-default-features --features native-tls-vendored
 
 FROM ruby:3.3@sha256:bff96f25259cd10bd92955bd84f2995230d5144ec0cdd5dc05384b302b3d3270 AS builder-gem
 WORKDIR /gem

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -2,7 +2,7 @@
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
 
-RUN yum -y install gcc libffi-devel glibc-devel make
+RUN yum -y install gcc libffi-devel perl-core glibc-devel make
 
 RUN useradd -m builder \
     && mkdir -p /pyroscope-rs \
@@ -23,6 +23,7 @@ WORKDIR /pyroscope-rs
 RUN /opt/python/cp39-cp39/bin/python -m pip install --user build
 
 ADD --chown=builder:builder pyproject.toml \
+    setup.py \
     rustfmt.toml \
     Cargo.toml \
     Cargo.lock \
@@ -30,6 +31,11 @@ ADD --chown=builder:builder pyproject.toml \
 
 ADD --chown=builder:builder src src
 ADD --chown=builder:builder pyroscope_ffi/ pyroscope_ffi/
+
+ARG PYROSCOPE_CARGO_NO_DEFAULT_FEATURES=1
+ARG PYROSCOPE_CARGO_FEATURES=native-tls-vendored
+ENV PYROSCOPE_CARGO_NO_DEFAULT_FEATURES=${PYROSCOPE_CARGO_NO_DEFAULT_FEATURES}
+ENV PYROSCOPE_CARGO_FEATURES=${PYROSCOPE_CARGO_FEATURES}
 
 RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
     --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,6 @@ find = { where = ["pyroscope_ffi/python/python/"] }
 [tool.distutils.bdist_wheel]
 py_limited_api = "cp39"
 
-[[tool.setuptools-rust.ext-modules]]
-target = "pyroscope_python_extension.pyroscope_python_extension"
-path = "pyroscope_ffi/python/rust/Cargo.toml"
-binding = "NoBinding"
-cargo_manifest_args=["--locked"]
 
 [build-system]
 requires = [

--- a/pyroscope_ffi/python/rust/Cargo.toml
+++ b/pyroscope_ffi/python/rust/Cargo.toml
@@ -13,8 +13,13 @@ crate-type = ["cdylib"]
 name = "pyroscope_python_extension" # this is the name of the shared rust, e.g. pyroscope_python_extension.abi3.so
 
 [dependencies]
-pyroscope = { path  = "../../../" }
+pyroscope = { path  = "../../../", default-features = false }
 py-spy = { git = "https://github.com/grafana/py-spy", rev = "3b390dc4230207914164e1dd6888eb3e680b1560" }
 pretty_env_logger = "0.5.0"
 log = "0.4"
 libc = "0.2.181"
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["pyroscope/rustls-tls"]
+native-tls-vendored = ["pyroscope/native-tls-vendored"]

--- a/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
+++ b/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
@@ -9,7 +9,7 @@ name = "rbspy"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyroscope = { path = "../../../../" }
+pyroscope = { path = "../../../../", default-features = false }
 rbspy = { version="0.42" }
 remoteprocess = "0.5.0"
 anyhow = "1.0"
@@ -17,3 +17,8 @@ anyhow = "1.0"
 pretty_env_logger = "0.5"
 log = "0.4"
 libc = "0.2.180"
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["pyroscope/rustls-tls"]
+native-tls-vendored = ["pyroscope/native-tls-vendored"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import os
+
+from setuptools import setup
+from setuptools_rust import Binding, RustExtension
+
+cargo_args = ["--locked"]
+features = []
+
+if os.getenv("PYROSCOPE_CARGO_NO_DEFAULT_FEATURES"):
+    cargo_args.append("--no-default-features")
+
+extra_features = os.getenv("PYROSCOPE_CARGO_FEATURES")
+if extra_features:
+    features = extra_features.split(",")
+
+setup(
+    rust_extensions=[
+        RustExtension(
+            "pyroscope_python_extension.pyroscope_python_extension",
+            path="pyroscope_ffi/python/rust/Cargo.toml",
+            binding=Binding.NoBinding,
+            cargo_manifest_args=cargo_args,
+            features=features,
+        )
+    ],
+)


### PR DESCRIPTION
## What changed

Switch the Python wheel and Ruby gem Docker builds from rustls (the default) to statically compiled/vendored OpenSSL via reqwest's `native-tls-vendored` feature. Local builds (`python -m build`, macOS CI) continue using rustls by default — only the Docker-based Linux builds use vendored OpenSSL.

## Why

The manylinux2014 build containers produce portable Linux binaries. Using vendored OpenSSL (compiled from source and linked statically) means the resulting `.so` files have no runtime dependency on system OpenSSL, which is the right choice for distributable binary packages.

## Implementation details

### Cargo feature plumbing
- Added `native-tls-vendored = ["reqwest/native-tls-vendored"]` feature to the root `Cargo.toml`
- Added `[features]` sections to both FFI crates (`pyroscope_python_extension` and `ffiruby`) that expose `rustls-tls` and `native-tls-vendored`, forwarding them to the `pyroscope` dependency. The `pyroscope` dep is set to `default-features = false` so each FFI crate fully controls TLS selection
- Updated `Cargo.lock` to include the new `openssl-src` transitive dependency

### Python Docker build (`docker/wheel.Dockerfile`)
- Added `setup.py` — reads `PYROSCOPE_CARGO_NO_DEFAULT_FEATURES` and `PYROSCOPE_CARGO_FEATURES` env vars to configure the `RustExtension` at build time, replacing the static `[[tool.setuptools-rust.ext-modules]]` section in `pyproject.toml`
- The Dockerfile sets `ARG`/`ENV` directives for `PYROSCOPE_CARGO_NO_DEFAULT_FEATURES=1` and `PYROSCOPE_CARGO_FEATURES=native-tls-vendored`, which can be overridden at `docker build` time via `--build-arg`
- Removed `openssl-devel` from the yum install — vendored OpenSSL compiles its own sources and doesn't need system headers
- Added `perl-core` to the yum install — the OpenSSL `./Configure` build script requires Perl modules (`IPC::Cmd`, `Time::Piece`, etc.) that aren't in manylinux2014's minimal Perl install

### Ruby Docker build (`docker/gem.Dockerfile`)
- Added `--no-default-features --features native-tls-vendored` to the `cargo build` command
- Removed `openssl-devel`, added `perl-core` (same reasoning as above)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)