### PR TITLE
fix: sdist not uploaded to GitHub release due to filename normalization

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -114,7 +114,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           draft: true
-          files: dist/pyroscope-io-*.tar.gz
+          files: dist/pyroscope_io-*.tar.gz
   python-release:
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Fixes \`pyroscope-io\` failing to install via \`uv\` on musl-based Linux (Alpine) and in universal lockfile scenarios.

## Root Cause

The sdist (source distribution) was never published to PyPI for any recent release. The release workflow used the glob pattern \`dist/pyroscope-io-*.tar.gz\` to upload the sdist to the GitHub release, but [PEP 625](https://peps.python.org/pep-0625/) normalizes package names in filenames — \`python -m build --sdist\` produces \`pyroscope_io-*.tar.gz\` (underscore, not hyphen). The glob silently matched nothing, so the sdist was omitted from every GitHub release and consequently never published to PyPI.

This was confirmed in the CI logs for \`python-1.0.3\`:
\`\`\`
Pattern 'dist/pyroscope-io-*.tar.gz' does not match any files.
\`\`\`

## Impact

Without an sdist on PyPI, \`uv\` fails to install \`pyroscope-io\` in several scenarios:

- **musl-based Linux (Alpine)**: manylinux wheels are glibc-only and incompatible with musl. On v0.8.11 (no musllinux wheels), \`uv sync\` fails with the exact error from issue #228
- **Universal lockfile resolution**: \`uv lock\` resolves for all platforms simultaneously. Without an sdist fallback for platforms without wheels (e.g. Windows), resolution fails
- **\`--no-binary\` builds**: Impossible without an sdist

## Fix

One-line fix: change the sdist upload glob in \`release-python.yml\` from \`pyroscope-io-*.tar.gz\` to \`pyroscope_io-*.tar.gz\`.

## Reproduction

Reproduced locally using Docker with QEMU arm64 emulation (\`python:3.10-alpine\`, \`linux/arm64\`):
- v0.8.11 on Alpine arm64 → **fails** (no musllinux wheels, no sdist) — exact issue #228 error
- v1.0.3 on Alpine arm64 → **works** (musllinux wheels added in recent releases)
- v1.0.3 with \`--no-binary\` → **fails** (confirms no sdist on PyPI even for latest)

Closes #228