### PR TITLE
ci: use crates.io trusted publishing for Rust crate

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -23,7 +23,7 @@ jobs:
           toolchain: 1.85.0
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
       - name: publish pyroscope crate
         run: cargo publish
         env:


### PR DESCRIPTION
## What

Switch the `publish-rust-crate.yml` workflow from long-lived API token authentication to [crates.io trusted publishing](https://blog.crates.io/2024/10/16/announcing-trusted-publishing/) (OIDC-based).

## Why

The previous approach stored a persistent `CARGO_TOKEN` API token as a GitHub Actions secret. Long-lived tokens are a supply-chain risk — if leaked (e.g. via a compromised action or log exposure), they can be used to publish malicious versions of the crate until manually revoked.

Crates.io trusted publishing uses GitHub's OIDC provider to issue a short-lived token scoped to a single workflow run. No secret needs to be stored or rotated.

## Changes

- Added `id-token: write` permission to allow the job to request a GitHub OIDC token.
- Replaced `cargo login ${{ secrets.CARGO_TOKEN }}` with the official `rust-lang/crates-io-auth-action@v1` action, which exchanges the OIDC token for a temporary crates.io access token.
- Pass the short-lived token to `cargo publish` via the `CARGO_REGISTRY_TOKEN` environment variable.

## Prerequisites

Before this workflow can succeed, a **trusted publisher** must be configured on crates.io for the `pyroscope` crate:

- Go to the crate's settings on crates.io
- Add a trusted publisher pointing to this repository and workflow file (`.github/workflows/publish-rust-crate.yml`)