### PR TITLE
chore: prepare Rust crate v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v0.6.0
+## Breaking Changes
+- Removed `auth_token` from Python and Ruby FFI bindings and related code
+- Removed `detect_subprocesses` from Python and Ruby configs
+- Config constructor now requires app/spy identity and sample rate inputs
+- Removed support for collapsed format
+- Removed global tags from ruleset
+
+## New Features
+- Integrated pprof-rs backend into main crate behind optional `backend-pprof-rs` feature
+- Switched to push API (from `/ingest` to `/push`)
+- Generated push API protos
+- Added `ThreadId` type
+- Added `rustls-no-provider` TLS feature
+
+## Bug Fixes / Improvements
+- Unified signal logic
+- Report cleanup functions
+- Optimized ruleset
+- Removed obscure thread id hash check
+- Ruby: inline thread_id crate; remove detect_subprocess
+- Dependency updates (reqwest 0.13, prost 0.14, thiserror 2.0, serde_json 1.0.115, uuid 1.20, libflate 2.1)
+
 # v0.5.4
 ## New Features
 - Add report transfromation function which allows changing the report before

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "assert_matches",
  "claims",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Pyroscope Profiler Agent for continuous profiling of Rust, Python and Ruby appli
 """
 keywords = ["pyroscope", "profiler", "profiling", "pprof"]
 authors = ["Abid Omar <contact@omarabid.com>"]
-version = "0.5.9"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://pyroscope.io/docs/rust"


### PR DESCRIPTION
## Summary

- Bumps the `pyroscope` Rust crate version from `0.5.9` to `0.6.0` in `Cargo.toml` and `Cargo.lock`
- Adds a `v0.6.0` entry to `CHANGELOG.md` documenting all changes since the last release (`v0.5.4`)

## Why

The crate has accumulated many significant changes since the last published version (`lib-0.5.9`) and is ready for a new release. The changes include breaking API changes, new features, and dependency updates that collectively warrant a minor version bump.

## Changes since v0.5.9

### Breaking Changes
- Removed `auth_token` from Python and Ruby FFI bindings
- Removed `detect_subprocesses` from Python and Ruby configs
- Config constructor now requires app/spy identity and sample rate as inputs
- Removed support for collapsed format
- Removed global tags from ruleset

### New Features
- Integrated `pprof-rs` backend into the main crate behind the optional `backend-pprof-rs` feature flag
- Switched to push API (from `/ingest` to `/push`) with generated protobuf definitions
- Added `ThreadId` type
- Added `rustls-no-provider` TLS feature

### Bug Fixes / Improvements
- Unified signal logic
- Report cleanup functions
- Optimized ruleset
- Removed obscure thread id hash check
- Dependency updates: `reqwest` 0.13, `prost` 0.14, `thiserror` 2.0, `serde_json` 1.0.115, `uuid` 1.20, `libflate` 2.1

## Publishing

Once merged, create a GitHub release with the tag `lib-0.6.0` to trigger the `.github/workflows/publish-rust-crate.yml` workflow, which will publish the crate to crates.io via trusted publishing.