### PR TITLE
chore: prepare Rust crate v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.6.0
+# v1.0.0
 ## Breaking Changes
 - Removed `auth_token` from Python and Ruby FFI bindings and related code
 - Removed `detect_subprocesses` from Python and Ruby configs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "pyroscope"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches",
  "claims",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Pyroscope Profiler Agent for continuous profiling of Rust, Python and Ruby appli
 """
 keywords = ["pyroscope", "profiler", "profiling", "pprof"]
 authors = ["Abid Omar <contact@omarabid.com>"]
-version = "0.6.0"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://pyroscope.io/docs/rust"


### PR DESCRIPTION
## Summary

- Bumps the `pyroscope` Rust crate to major version `1.0.0` in `Cargo.toml` and `Cargo.lock`
- Updates `CHANGELOG.md` with a `v1.0.0` entry

## Why

The crate has accumulated significant **breaking API changes** since the last published version (`lib-0.5.9`) that warrant a major version bump rather than a minor one:

### Breaking Changes
- Removed `auth_token` from Python and Ruby FFI bindings and config
- Removed `detect_subprocesses` from Python and Ruby configs
- Config constructor now requires app/spy identity and sample rate as mandatory inputs
- Removed support for collapsed format
- Removed global tags from ruleset
- Switched from `/ingest` to push API (new protobuf-based wire format)

### New Features
- Integrated `pprof-rs` backend into the main crate behind the optional `backend-pprof-rs` feature flag
- Generated push API protos with `ThreadId` type
- Added `rustls-no-provider` TLS feature

### Improvements
- Unified signal logic
- Report cleanup functions
- Optimized ruleset
- Dependency updates: `reqwest` 0.13, `prost` 0.14, `thiserror` 2.0, `serde_json` 1.0.115, `uuid` 1.20, `libflate` 2.1

## Publishing

Once merged, create a GitHub release with the tag `lib-1.0.0` to trigger the `.github/workflows/publish-rust-crate.yml` workflow, which will publish to crates.io via trusted publishing.