### PR TITLE
chore: update wasm-bindgen ecosystem to fix yanked package warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3297,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3310,9 +3310,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.61"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3334,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3347,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -3390,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## Summary

- Updated  from v0.4.61 → v0.4.63, which transitively resolves the entire wasm-bindgen ecosystem to non-yanked versions
- Fixes Cargo warnings about yanked packages in `Cargo.lock`

## Changes

| Package | Before | After |
|---|---|---|
| `js-sys` | 0.3.88 (yanked) | 0.3.90 |
| `wasm-bindgen` | 0.2.111 (yanked) | 0.2.113 |
| `wasm-bindgen-futures` | 0.4.61 | 0.4.63 |
| `wasm-bindgen-macro` | 0.2.111 | 0.2.113 |
| `wasm-bindgen-macro-support` | 0.2.111 | 0.2.113 |
| `wasm-bindgen-shared` | 0.2.111 | 0.2.113 |
| `web-sys` | 0.3.88 | 0.3.90 |

## Why

`js-sys v0.3.88` and `wasm-bindgen v0.2.111` were yanked from crates.io, causing `cargo` to emit warnings on every build. The root cause was `reqwest v0.13.2` (the latest) pulling in `wasm-bindgen-futures v0.4.61`, which in turn used exact-version pins (`=0.3.88`, `=0.2.111`) to the yanked crates. Bumping `wasm-bindgen-futures` to v0.4.63 (which uses updated pins) resolves the entire chain in one step.

## Implementation Details

Only `Cargo.lock` is modified — no `Cargo.toml` changes are needed since the version constraints in `reqwest` already allow the newer patch versions.