### PR TITLE
chore: replace pprof crate with Grafana fork (pprof-pyroscope-fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,10 +1974,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pprof"
-version = "0.15.0"
+name = "pprof-pyroscope-fork"
+version = "0.1500.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+checksum = "a81f1489b882945ce89a4c93dbb50b1bf31839188d3c83fb5e5eded6bad6ee2d"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -2143,7 +2143,7 @@ dependencies = [
  "libflate",
  "log",
  "names",
- "pprof",
+ "pprof-pyroscope-fork",
  "prost",
  "reqwest",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ libflate = "2.1.0"
 libc = "^0.2.124"
 prost = "0.14"
 serde_json = "1.0.115"
-pprof = { version = "0.15", features = ["framehop", "framehop-unwinder"], optional = true }
+pprof = { package = "pprof-pyroscope-fork", version = "0.1500.1", features = ["framehop", "framehop-unwinder"], optional = true }
 lazy_static = "1.5.0"
 
 [dev-dependencies]


### PR DESCRIPTION
## What

Replaces the upstream [`pprof`](https://crates.io/crates/pprof) crate (v0.15) with the Grafana-maintained fork [`pprof-pyroscope-fork`](https://crates.io/crates/pprof-pyroscope-fork) (v0.1500.1).

## Why

The Grafana fork (`grafana/pprof-rs`) contains fixes and improvements specific to Pyroscope's use case that have not been merged upstream. Using the fork ensures we get those fixes while staying aligned with the broader Grafana/Pyroscope ecosystem.

## Implementation details

- In `Cargo.toml`, the dependency uses the `package` key to pull `pprof-pyroscope-fork` from crates.io while keeping the local alias `pprof`:
  ```toml
  pprof = { package = "pprof-pyroscope-fork", version = "0.1500.1", features = ["framehop", "framehop-unwinder"], optional = true }
  ```
- Because the fork preserves the Rust crate name `pprof` internally, **no source code changes are required** — all existing `use pprof::` imports continue to compile without modification.