### PR TITLE
ci: use large runner for publish-rust-crate workflow

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   publish-pyroscope:
     name: pyroscope-lib
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-x64-large
     if: "startsWith(github.event.release.tag_name, 'lib-')"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Updates the `publish-rust-crate.yml` workflow to use `ubuntu-x64-large` instead of `ubuntu-x64-small`

## Why

The `cargo publish` step involves compiling the crate, which can be resource-intensive. Other workflows in this repo that perform builds (Python FFI, Ruby FFI, release workflows) already use `ubuntu-x64-large`. This change brings the publish workflow in line with the rest of the project for consistency and to avoid potential OOM or timeout issues on the small runner.

## Details

- Changed `runs-on: ubuntu-x64-small` → `runs-on: ubuntu-x64-large` in the `publish-pyroscope` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)