### PR TITLE
chore: centralize all dependency versions in workspace root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,26 +24,47 @@ members = [
     "pyroscope_ffi/python/rust",
 ]
 
-
-
-
-[dependencies]
+[workspace.dependencies]
 thiserror = "2.0.12"
 log = "0.4"
 names = { version = "0.14.0", default-features = false }
 reqwest = { version = "0.13", features = ["blocking", "query"], default-features = false }
-uuid = { version = "1.20.0" , features = ["v4"]}
+uuid = { version = "1.20.0", features = ["v4"] }
 url = "2.2.2"
 libflate = "2.1.0"
 libc = "^0.2.124"
 prost = "0.14"
 serde_json = "1.0.115"
-pprof = { package = "pprof-pyroscope-fork", version = "0.1500.1", features = ["framehop", "framehop-unwinder"], optional = true }
+pprof = { package = "pprof-pyroscope-fork", version = "0.1500.1", features = ["framehop", "framehop-unwinder"] }
 lazy_static = "1.5.0"
-
-[dev-dependencies]
 assert_matches = "=1.5.0"
 claims = "=0.8.0"
+pretty_env_logger = "0.5.0"
+rbspy = { version = "0.42" }
+remoteprocess = "0.5.0"
+anyhow = "1.0"
+py-spy = { git = "https://github.com/grafana/py-spy", rev = "3b390dc4230207914164e1dd6888eb3e680b1560" }
+
+
+
+
+[dependencies]
+thiserror = { workspace = true }
+log = { workspace = true }
+names = { workspace = true }
+reqwest = { workspace = true }
+uuid = { workspace = true }
+url = { workspace = true }
+libflate = { workspace = true }
+libc = { workspace = true }
+prost = { workspace = true }
+serde_json = { workspace = true }
+pprof = { workspace = true, optional = true }
+lazy_static = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+claims = { workspace = true }
 
 [features]
 default = ["rustls-tls"]

--- a/pyroscope_ffi/python/rust/Cargo.toml
+++ b/pyroscope_ffi/python/rust/Cargo.toml
@@ -13,11 +13,11 @@ crate-type = ["cdylib"]
 name = "pyroscope_python_extension" # this is the name of the shared rust, e.g. pyroscope_python_extension.abi3.so
 
 [dependencies]
-pyroscope = { path  = "../../../", default-features = false }
-py-spy = { git = "https://github.com/grafana/py-spy", rev = "3b390dc4230207914164e1dd6888eb3e680b1560" }
-pretty_env_logger = "0.5.0"
-log = "0.4"
-libc = "0.2.181"
+pyroscope = { path = "../../../", default-features = false }
+py-spy = { workspace = true }
+pretty_env_logger = { workspace = true }
+log = { workspace = true }
+libc = { workspace = true }
 
 [features]
 default = ["rustls-tls"]

--- a/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
+++ b/pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
@@ -10,13 +10,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyroscope = { path = "../../../../", default-features = false }
-rbspy = { version="0.42" }
-remoteprocess = "0.5.0"
-anyhow = "1.0"
+rbspy = { workspace = true }
+remoteprocess = { workspace = true }
+anyhow = { workspace = true }
 # todo remove this dependency
-pretty_env_logger = "0.5"
-log = "0.4"
-libc = "0.2.180"
+pretty_env_logger = { workspace = true }
+log = { workspace = true }
+libc = { workspace = true }
 
 [features]
 default = ["rustls-tls"]


### PR DESCRIPTION
## Summary

- Adds a `[workspace.dependencies]` section to the root `Cargo.toml` listing all dependencies (including those exclusive to member crates) with their versions
- Updates the root crate's `[dependencies]` and `[dev-dependencies]` to reference workspace deps via `workspace = true`
- Updates `pyroscope_ffi/python/rust/Cargo.toml` and `pyroscope_ffi/ruby/ext/rbspy/Cargo.toml` to reference shared deps (`log`, `libc`, `pretty_env_logger`, `py-spy`, `rbspy`, `remoteprocess`, `anyhow`) via `workspace = true`

## Why

Previously, dependency versions were duplicated across multiple `Cargo.toml` files, with some minor version drift between crates (e.g. `libc` was `0.2.181` in the Python crate and `0.2.180` in the Ruby crate). Centralizing versions in `[workspace.dependencies]` ensures consistency across all workspace members and makes future version bumps a single-line change in one file.

## Implementation details

- The `pprof` entry in `[workspace.dependencies]` omits `optional = true` (workspace dep declarations don't support that flag); `optional = true` is kept on the per-crate usage in `[dependencies]`
- The `pyroscope` path dependency in each FFI crate remains a local `path = ...` reference (not a workspace dep) since it is the root crate itself
- All three crates compile cleanly (`cargo check --workspace` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)