### PR TITLE
ci: switch Python PyPI publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -26,6 +26,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove hardcoded `user: __token__` and `password: ${{ secrets.PYPI_API_TOKEN }}` credentials from `publish-python.yml`
- The workflow already had `id-token: write` permission; this change makes it actually use OIDC trusted publishing instead of a long-lived API token

## Why

Trusted publishing (OIDC) is the recommended way to publish to PyPI. It eliminates the need for a long-lived `PYPI_API_TOKEN` secret by using short-lived identity tokens issued by GitHub Actions, reducing the risk of secret exposure or compromise.

This follows the same pattern already adopted for the Rust crate publishing workflow (#381).

## Required PyPI configuration

A trusted publisher must be configured on PyPI for this to work:
- **Owner**: `grafana`
- **Repository**: `pyroscope-rs`
- **Workflow**: `publish-python.yml`
- **Environment**: (none)

Once configured, the `PYPI_API_TOKEN` repository secret can be removed.