### PR TITLE
ci: add release-please and PR title check workflows

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,39 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title follows conventional commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Check if PR title starts with allowed conventional commit types
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(!)?:'; then
+            echo "✓ PR title follows conventional commits format"
+            exit 0
+          else
+            echo "✗ PR title must use conventional commit format: <type>: <description>"
+            echo "  Current title: $PR_TITLE"
+            echo ""
+            echo "Allowed types:"
+            echo "  feat:     new feature (minor bump)"
+            echo "  fix:      bug fix (patch bump)"
+            echo "  perf:     performance improvement (patch bump)"
+            echo "  docs:     documentation (patch bump)"
+            echo "  refactor: code refactoring (patch bump)"
+            echo "  test:     tests (patch bump)"
+            echo "  ci:       CI/CD changes (patch bump)"
+            echo "  chore:    maintenance (patch bump)"
+            echo "  build:    build system (patch bump)"
+            echo "  style:    code style (patch bump)"
+            echo "  revert:   revert changes (patch bump)"
+            echo ""
+            echo "Add ! for breaking changes (major bump): feat!:, fix!:, etc."
+            exit 1
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+
+name: Release Please
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Run release-please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  ".": "1.0.2",
+  "pyroscope_ffi/python/rust": "1.0.4",
+  "pyroscope_ffi/ruby": "1.0.1"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyroscope-io"
-version = "1.0.4"
+version = "1.0.4" # x-release-please-version
 description = "Pyroscope Python integration"
 authors = [
     {name = "Tolya Korniltsev",email = "anatoly.korniltsev@grafana.com"}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "packages": {
+    ".": {
+      "component": "lib",
+      "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
+      "include-v-in-tag": false,
+      "include-component-in-tag": true,
+      "extra-files": [],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "style", "section": "Styles"},
+        {"type": "chore", "section": "Miscellaneous Chores"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "test", "section": "Tests"},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"}
+      ]
+    },
+    "pyroscope_ffi/python/rust": {
+      "component": "python",
+      "release-type": "rust",
+      "changelog-path": "CHANGELOG.md",
+      "include-v-in-tag": false,
+      "include-component-in-tag": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "../../../pyproject.toml"
+        }
+      ],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "style", "section": "Styles"},
+        {"type": "chore", "section": "Miscellaneous Chores"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "test", "section": "Tests"},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"}
+      ]
+    },
+    "pyroscope_ffi/ruby": {
+      "component": "ruby",
+      "release-type": "ruby",
+      "changelog-path": "CHANGELOG.md",
+      "include-v-in-tag": false,
+      "include-component-in-tag": true,
+      "extra-files": [
+        {
+          "type": "cargo-toml",
+          "path": "ext/rbspy/Cargo.toml"
+        }
+      ],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "style", "section": "Styles"},
+        {"type": "chore", "section": "Miscellaneous Chores"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "test", "section": "Tests"},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"}
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add [release-please](https://github.com/googleapis/release-please) for automated versioning, changelog generation, and release PR creation (same approach as [pprof-rs](https://github.com/grafana/pprof-rs))
- Add PR title validation workflow to enforce conventional commit format, which release-please uses to determine version bumps
- Configure three independently-versioned release components: **lib** (Rust crate), **python** (PyPI package), and **ruby** (RubyGems gem)

## What changed

### release-please configuration (`release-please-config.json`, `.release-please-manifest.json`)

Multi-package setup with `"separate-pull-requests": true` so each component gets its own release PR:

| Component | Path | Release type | Tag format | Version files bumped |
|-----------|------|-------------|------------|---------------------|
| **lib** | `.` | `rust` | `lib-X.Y.Z` | `Cargo.toml` |
| **python** | `pyroscope_ffi/python/rust` | `rust` | `python-X.Y.Z` | `pyroscope_ffi/python/rust/Cargo.toml`, `pyproject.toml` (via generic updater) |
| **ruby** | `pyroscope_ffi/ruby` | `ruby` | `ruby-X.Y.Z` | `pyroscope_ffi/ruby/lib/pyroscope/version.rb`, `pyroscope_ffi/ruby/ext/rbspy/Cargo.toml` (via cargo-toml updater) |

Tag format preserves the existing convention (`lib-1.0.2`, `python-1.0.4`, `ruby-1.0.1` — no `v` prefix), so no changes were needed to existing release/publish workflows.

The manifest is seeded with current versions: lib=1.0.2, python=1.0.4, ruby=1.0.1.

### Workflows

- **`.github/workflows/release-please.yml`** — Runs on push to `main`, creates/updates release PRs via `googleapis/release-please-action@v4`
- **`.github/workflows/pr-title-check.yml`** — Validates PR titles match `<type>[!]: <description>` format on open/edit/sync/reopen

### `pyproject.toml`

Added `# x-release-please-version` annotation to the version line so the generic updater can find and bump the Python package version during python release PRs.

## How it works

1. PRs are merged with conventional commit titles (enforced by `pr-title-check.yml`)
2. On push to `main`, release-please analyzes commits since the last release tag for each component
3. If there are releasable changes, it creates/updates a release PR with version bump + changelog
4. Merging a release PR creates a git tag (e.g. `python-1.0.5`), which triggers the existing release build + publish workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)