### PR TITLE
ci: fix PR title check and version script for renovate PRs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -14,11 +14,11 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Check if PR title starts with allowed conventional commit types
-          if echo "$PR_TITLE" | grep -qE '^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(!)?:'; then
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\(.+\))?(!)?:'; then
             echo "✓ PR title follows conventional commits format"
             exit 0
           else
-            echo "✗ PR title must use conventional commit format: <type>: <description>"
+            echo "✗ PR title must use conventional commit format: <type>[(<scope>)][!]: <description>"
             echo "  Current title: $PR_TITLE"
             echo ""
             echo "Allowed types:"

--- a/ci/check-spy-versions.sh
+++ b/ci/check-spy-versions.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-py_cfg_version=$(awk -F'=' '/^version[[:space:]]*=/{gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyproject.toml)
+py_cfg_version=$(awk -F'=' '/^version[[:space:]]*=/{sub(/#.*/, "", $2); gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyproject.toml)
 rb_version=$(sed -nE "s/.*VERSION = '([^']+)'.*/\1/p" pyroscope_ffi/ruby/lib/pyroscope/version.rb)
 
 py_rust_version=$(awk -F'=' '/^version[[:space:]]*=/{gsub(/[[:space:]"]/, "", $2); print $2; exit}' pyroscope_ffi/python/rust/Cargo.toml)


### PR DESCRIPTION
## Summary

Fix two CI checks that fail on renovate PRs (e.g. #407):

- **PR title check**: support scoped conventional commits like `chore(deps):`
- **check-spy-versions**: strip `# x-release-please-version` comments when parsing `pyproject.toml`

## Changes

### PR title check (`.github/workflows/pr-title-check.yml`)

The regex only matched `<type>[!]:` but not `<type>(<scope>)[!]:`. Renovate generates titles like `chore(deps): update rust crate pprof to v0.1500.3` which include a scope, causing the check to reject valid conventional commit titles.

**Fix**: Added `(\(.+\))?` optional scope group to the grep pattern, and updated the error message to document the full format.

### Version check script (`ci/check-spy-versions.sh`)

The awk command that extracts the version from `pyproject.toml` didn't account for inline comments. The line:
```
version = "1.0.4" # x-release-please-version
```
was parsed as `1.0.4#x-release-please-version` instead of `1.0.4`, causing a false mismatch with the Cargo.toml version.

**Fix**: Added `sub(/#.*/, "", $2)` to strip inline comments before extracting the version.

## Test plan

- [x] `ci/check-spy-versions.sh` passes locally
- [ ] `Validate PR Title` check passes on this PR
- [ ] `check-spy-versions` check passes on this PR
- [ ] Renovate PR #407 CI passes after rebasing on top of this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)