### PR TITLE
ci: use github-hosted runners on forks, grafana runners on upstream

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-generated-ffi:
     name: Check generated FFI files
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,16 +35,16 @@ jobs:
       matrix:
         include:
           - name: manylinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             make-target: wheel/linux/amd64
           - name: manylinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             make-target: wheel/linux/arm64
           - name: musllinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             make-target: wheel/musllinux/amd64
           - name: musllinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             make-target: wheel/musllinux/arm64
     name: Linux Build - ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
@@ -76,16 +76,16 @@ jobs:
         variant: ["manylinux-amd64", "manylinux-arm64", "musllinux-amd64", "musllinux-arm64"]
         include:
           - variant: manylinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             image-suffix: slim
           - variant: manylinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             image-suffix: slim
           - variant: musllinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             image-suffix: alpine
           - variant: musllinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             image-suffix: alpine
         exclude:
           # python:3.10/3.11-alpine arm64 tests hang indefinitely
@@ -115,7 +115,7 @@ jobs:
 
   sdist-build:
     name: sdist
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   check-generated-header:
     name: Check generated Ruby header
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,7 +27,7 @@ jobs:
 
   linux-build:
     name: Build linux gem amd64
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -84,7 +84,7 @@ jobs:
         RUBY_VERSION: ['3.1', '3.2', '3.3', '3.3.8', '3.4.3', '3.4.6']
     needs: ['linux-build']
     name: Linux Test
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     steps:
       - uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   format:
     name: cargo fmt --check
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -28,7 +28,7 @@ jobs:
 
   clippy:
     name: cargo clippy
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -44,7 +44,7 @@ jobs:
 
   test:
     name: cargo test (${{ matrix.package }})
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       id-token: write
     name: "Python"
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     if: "startsWith(github.event.release.tag_name, 'python-')"
     steps:
       - uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # 1.12

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   push-ruby-gems:
     name: "Push ruby gems"
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     if: "startsWith(github.event.release.tag_name, 'ruby-')"
     outputs:
       files_json: ${{ steps.list-files.outputs.files_json }}

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   publish-pyroscope:
     name: pyroscope-lib
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     if: "startsWith(github.event.release.tag_name, 'lib-')"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -15,16 +15,16 @@ jobs:
       matrix:
         include:
           - name: manylinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             make-target: wheel/linux/amd64
           - name: manylinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             make-target: wheel/linux/arm64
           - name: musllinux-amd64
-            runs-on: ubuntu-x64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
             make-target: wheel/musllinux/amd64
           - name: musllinux-arm64
-            runs-on: ubuntu-arm64-large
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             make-target: wheel/musllinux/arm64
     name: Release python linux - ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
@@ -93,7 +93,7 @@ jobs:
       contents: write
     needs: [ 'python-release' ]
     name: sdist
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: write
     name: Python Package
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     needs: [ 'ruby-release' ]
     name: Release Linux gem amd64
-    runs-on: ubuntu-x64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -34,7 +34,7 @@ jobs:
       contents: write
     needs: [ 'ruby-release' ]
     name: Release Linux gem arm64
-    runs-on: ubuntu-arm64-large
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -99,7 +99,7 @@ jobs:
       contents: write
     needs: [ 'ruby-release' ]
     name: source
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -133,7 +133,7 @@ jobs:
     permissions:
       contents: write
     name: Ruby Gem
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: write
     name: pyroscope-main
-    runs-on: ubuntu-x64-small
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     if: "startsWith(github.ref, 'refs/tags/lib-')"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Workflows fail with `startup_failure` on forks because they reference Grafana self-hosted runners (`ubuntu-x64-small`, `ubuntu-x64-large`, `ubuntu-arm64-large`) that don't exist outside the Grafana org
- Use inline ternary expressions on `github.repository_owner` to select runners: Grafana self-hosted when owner is `grafana`, GitHub-hosted (`ubuntu-latest`, `ubuntu-24.04-arm`) otherwise
- 9 workflow files updated, 31 `runs-on:` replacements total

## Test plan

- [ ] CI workflows start successfully on this PR (no `startup_failure`)
- [ ] On Grafana org, `github.repository_owner == 'grafana'` evaluates true → Grafana runners used as before
- [ ] On forks, fallback to `ubuntu-latest` / `ubuntu-24.04-arm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)