### PR TITLE
ci: pin get-vault-secrets action to commit SHA

### DIFF
--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -18,7 +18,7 @@ jobs:
       files_json: ${{ steps.list-files.outputs.files_json }}
     steps:
       - name: Get secrets from Vault
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@beb09ff2ba74e03329e99bc850246576a1c6cedb # main
         with:
           repo_secrets: |
             RUBYGEMS_API_KEY=publishing:rubygems_api_key


### PR DESCRIPTION
## Summary
- Pin `grafana/shared-workflows/actions/get-vault-secrets` from mutable `@main` branch ref to commit SHA `@beb09ff2ba74e03329e99bc850246576a1c6cedb`
- Fixes the zizmor `unpinned-uses` high-severity finding that was failing the "Run zizmor from current branch (self test)" CI check

## Context
The [zizmor](https://github.com/woodruffw/zizmor) security scanner flags unpinned GitHub Action references as a supply chain risk. Every other action in the repo is already pinned to a commit SHA — `get-vault-secrets@main` was the sole exception.

## Test plan
- [ ] Verify the "Run zizmor from current branch (self test)" CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)