### PR TITLE
ci: add pre-built Docker base images to speed up CI builds

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -1,0 +1,72 @@
+name: Build Base Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/base-*.Dockerfile'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io/${{ github.repository }}
+  BASE_VERSION: v1
+
+jobs:
+  build-base-images:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: builder-manylinux-x86_64
+            dockerfile: docker/base-manylinux.Dockerfile
+            platform: linux/amd64
+            build-arg-platform: x86_64
+            image-name: builder-manylinux
+            tag-suffix: x86_64
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+          - name: builder-manylinux-aarch64
+            dockerfile: docker/base-manylinux.Dockerfile
+            platform: linux/arm64
+            build-arg-platform: aarch64
+            image-name: builder-manylinux
+            tag-suffix: aarch64
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
+          - name: builder-musllinux-x86_64
+            dockerfile: docker/base-musllinux.Dockerfile
+            platform: linux/amd64
+            build-arg-platform: x86_64
+            image-name: builder-musllinux
+            tag-suffix: x86_64
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
+          - name: builder-musllinux-aarch64
+            dockerfile: docker/base-musllinux.Dockerfile
+            platform: linux/arm64
+            build-arg-platform: aarch64
+            image-name: builder-musllinux
+            tag-suffix: aarch64
+            runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
+
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push
+        run: |
+          docker buildx build \
+            --build-arg=PLATFORM=${{ matrix.build-arg-platform }} \
+            --platform=${{ matrix.platform }} \
+            -t ${{ env.REGISTRY }}/${{ matrix.image-name }}:${{ env.BASE_VERSION }}-${{ matrix.tag-suffix }} \
+            -f ${{ matrix.dockerfile }} \
+            --push \
+            .

--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   check-generated-ffi:
@@ -53,6 +54,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - run: make ${{ matrix.make-target }}
 

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   check-generated-header:
@@ -33,9 +34,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
-        with:
-          toolchain: stable
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - run: make gem/linux/amd64
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -9,6 +9,7 @@ jobs:
   python-release-linux:
     permissions:
       contents: write
+      packages: read
     needs: [ 'python-release' ]
     strategy:
       fail-fast: false
@@ -32,6 +33,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - run: make ${{ matrix.make-target }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -10,6 +10,7 @@ jobs:
   ruby-release-linux:
     permissions:
       contents: write
+      packages: read
     needs: [ 'ruby-release' ]
     name: Release Linux gem amd64
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
@@ -17,6 +18,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - run: make gem/linux/amd64
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -32,6 +37,7 @@ jobs:
   ruby-release-linux-arm:
     permissions:
       contents: write
+      packages: read
     needs: [ 'ruby-release' ]
     name: Release Linux gem arm64
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
@@ -39,6 +45,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
       - run: make gem/linux/arm64
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,17 +1,41 @@
-PREFIX ?= pyroscope/rust_builder
-CLI_BUILDER_VERSION ?= 3
-MANYLINUX_VERSION ?= 4
+REGISTRY ?= ghcr.io/grafana/pyroscope-rs
+BASE_VERSION ?= v1
 
-.PHONY: push_x86_64
-push_x86_64:
-	docker buildx build --platform linux/amd64 -t $(PREFIX)_manylinux2014_x86_64:$(MANYLINUX_VERSION) -f Dockerfile.manylinux2014_x86_64 --push .
+.PHONY: base/manylinux/amd64
+base/manylinux/amd64:
+	docker buildx build \
+		--build-arg=PLATFORM=x86_64 \
+		--platform=linux/amd64 \
+		-t $(REGISTRY)/builder-manylinux:$(BASE_VERSION)-x86_64 \
+		-f base-manylinux.Dockerfile \
+		--push .
 
-.PHONY: push_aarch64
-push_aarch64:
-	docker buildx build --platform linux/arm64 -t $(PREFIX)_manylinux2014_aarch64:$(MANYLINUX_VERSION) -f Dockerfile.manylinux2014_aarch64 --push .
+.PHONY: base/manylinux/arm64
+base/manylinux/arm64:
+	docker buildx build \
+		--build-arg=PLATFORM=aarch64 \
+		--platform=linux/arm64 \
+		-t $(REGISTRY)/builder-manylinux:$(BASE_VERSION)-aarch64 \
+		-f base-manylinux.Dockerfile \
+		--push .
 
+.PHONY: base/musllinux/amd64
+base/musllinux/amd64:
+	docker buildx build \
+		--build-arg=PLATFORM=x86_64 \
+		--platform=linux/amd64 \
+		-t $(REGISTRY)/builder-musllinux:$(BASE_VERSION)-x86_64 \
+		-f base-musllinux.Dockerfile \
+		--push .
 
-.PHONY: push_cli_builder
-push_cli_builder:
-	docker buildx build --platform linux/amd64,linux/arm64 -t $(PREFIX)_cli:$(CLI_BUILDER_VERSION) -f Dockerfile.cli_builder --push .
+.PHONY: base/musllinux/arm64
+base/musllinux/arm64:
+	docker buildx build \
+		--build-arg=PLATFORM=aarch64 \
+		--platform=linux/arm64 \
+		-t $(REGISTRY)/builder-musllinux:$(BASE_VERSION)-aarch64 \
+		-f base-musllinux.Dockerfile \
+		--push .
 
+.PHONY: base/all
+base/all: base/manylinux/amd64 base/manylinux/arm64 base/musllinux/amd64 base/musllinux/arm64

--- a/docker/Readme.txt
+++ b/docker/Readme.txt
@@ -1,4 +1,22 @@
-These dockerfile.manylinux* images do few things:
+Pre-built base Docker images for CI builds.
 
-1. rust toolchain, libunwind, deps were downloaded and installed on every build in manylinux.sh
-now they are installed once at image creation time
+base-manylinux.Dockerfile and base-musllinux.Dockerfile pre-install:
+- System packages (gcc, libffi, etc.)
+- Rust toolchain
+- Python build tools
+
+These are pushed to GHCR as:
+  ghcr.io/<repo>/builder-manylinux:v1-x86_64
+  ghcr.io/<repo>/builder-manylinux:v1-aarch64
+  ghcr.io/<repo>/builder-musllinux:v1-x86_64
+  ghcr.io/<repo>/builder-musllinux:v1-aarch64
+
+The manylinux base is shared by both Python wheel and Ruby gem builds.
+
+To rebuild manually: cd docker && make base/all
+Or trigger the build-base-images workflow via workflow_dispatch.
+
+When bumping Rust version or changing base dependencies:
+1. Update the base-*.Dockerfile files
+2. Bump BASE_VERSION in ffi.mk, docker/Makefile, and consumer Dockerfiles
+3. Merge to main (triggers automatic rebuild)

--- a/docker/base-manylinux.Dockerfile
+++ b/docker/base-manylinux.Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
+ARG PLATFORM=x86_64
+FROM quay.io/pypa/manylinux2014_${PLATFORM}
+
+RUN yum -y install gcc libffi-devel perl-core glibc-devel make wget gcc-c++
+
+# Install Rust to a shared location so both root and builder can use it.
+ENV RUST_VERSION=1.87
+ENV RUSTUP_HOME=/opt/rust/rustup
+ENV CARGO_HOME=/opt/rust/cargo
+RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu \
+    && rm /tmp/rustup-init \
+    && chmod -R a+rX /opt/rust
+ENV PATH=/opt/rust/cargo/bin:$PATH
+
+RUN useradd -m builder \
+    && mkdir -p /pyroscope-rs \
+    && chown builder:builder /pyroscope-rs
+
+USER builder
+RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
+
+WORKDIR /pyroscope-rs
+
+RUN /opt/python/cp310-cp310/bin/python -m pip install --user build

--- a/docker/base-musllinux.Dockerfile
+++ b/docker/base-musllinux.Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
+ARG PLATFORM=x86_64
+FROM quay.io/pypa/musllinux_1_2_${PLATFORM}
+
+RUN apk add --no-cache gcc musl-dev libffi-dev make
+
+RUN adduser -D builder \
+    && mkdir -p /pyroscope-rs \
+    && chown builder:builder /pyroscope-rs
+
+USER builder
+RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
+
+ENV RUST_VERSION=1.87
+RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \
+    && rm /tmp/rustup-init
+ENV PATH=/home/builder/.cargo/bin:$PATH
+
+WORKDIR /pyroscope-rs
+
+RUN /opt/python/cp310-cp310/bin/python -m pip install --user build

--- a/docker/gem.Dockerfile
+++ b/docker/gem.Dockerfile
@@ -1,13 +1,9 @@
 ARG PLATFORM=x86_64
-FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
+ARG BASE_VERSION=v1
+ARG REGISTRY=ghcr.io/grafana/pyroscope-rs
+FROM ${REGISTRY}/builder-manylinux:${BASE_VERSION}-${PLATFORM} AS builder
 
-ENV RUST_VERSION=1.87
-RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o ./rustup-init \
-    && chmod +x ./rustup-init \
-    && ./rustup-init  -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu
-ENV PATH=/root/.cargo/bin:$PATH
-RUN yum -y install gcc libffi-devel perl-core wget gcc-c++ glibc-devel make
-
+USER root
 WORKDIR /pyroscope-rs
 
 ADD rustfmt.toml \
@@ -19,7 +15,7 @@ ADD src src
 ADD kit/ kit/
 ADD pyroscope_ffi/ pyroscope_ffi/
 # TODO --frozen
-RUN --mount=type=cache,target=/root/.cargo/registry cargo build -p ffiruby --release --no-default-features --features native-tls-vendored
+RUN --mount=type=cache,target=/opt/rust/cargo/registry cargo build -p ffiruby --release --no-default-features --features native-tls-vendored
 
 FROM ruby:4.0@sha256:66302616aabd939350e9bd7bc31ccad5ef993a5ba5e93f0cc029bb82e80a8d3b AS builder-gem
 WORKDIR /gem

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -1,26 +1,8 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
-FROM quay.io/pypa/musllinux_1_2_${PLATFORM} AS builder
-
-RUN apk add --no-cache gcc musl-dev libffi-dev make
-
-RUN adduser -D builder \
-    && mkdir -p /pyroscope-rs \
-    && chown builder:builder /pyroscope-rs
-
-USER builder
-RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
-
-ENV RUST_VERSION=1.87
-RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
-    && chmod +x /tmp/rustup-init \
-    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \
-    && rm /tmp/rustup-init
-ENV PATH=/home/builder/.cargo/bin:$PATH
-
-WORKDIR /pyroscope-rs
-
-RUN /opt/python/cp310-cp310/bin/python -m pip install --user build
+ARG BASE_VERSION=v1
+ARG REGISTRY=ghcr.io/grafana/pyroscope-rs
+FROM ${REGISTRY}/builder-musllinux:${BASE_VERSION}-${PLATFORM} AS builder
 
 ADD --chown=builder:builder pyproject.toml \
     setup.py \

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -1,26 +1,8 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
-FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
-
-RUN yum -y install gcc libffi-devel perl-core glibc-devel make
-
-RUN useradd -m builder \
-    && mkdir -p /pyroscope-rs \
-    && chown builder:builder /pyroscope-rs
-
-USER builder
-RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
-
-ENV RUST_VERSION=1.87
-RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
-    && chmod +x /tmp/rustup-init \
-    && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu \
-    && rm /tmp/rustup-init
-ENV PATH=/home/builder/.cargo/bin:$PATH
-
-WORKDIR /pyroscope-rs
-
-RUN /opt/python/cp310-cp310/bin/python -m pip install --user build
+ARG BASE_VERSION=v1
+ARG REGISTRY=ghcr.io/grafana/pyroscope-rs
+FROM ${REGISTRY}/builder-manylinux:${BASE_VERSION}-${PLATFORM} AS builder
 
 ADD --chown=builder:builder pyproject.toml \
     setup.py \
@@ -38,8 +20,8 @@ ARG PYROSCOPE_CARGO_FEATURES=native-tls-vendored
 ENV PYROSCOPE_CARGO_NO_DEFAULT_FEATURES=${PYROSCOPE_CARGO_NO_DEFAULT_FEATURES}
 ENV PYROSCOPE_CARGO_FEATURES=${PYROSCOPE_CARGO_FEATURES}
 
-RUN --mount=type=cache,target=/home/builder/.cargo/registry,uid=1000,gid=1000 \
-    --mount=type=cache,target=/home/builder/.cargo/git,uid=1000,gid=1000 \
+RUN --mount=type=cache,target=/opt/rust/cargo/registry,uid=1000,gid=1000 \
+    --mount=type=cache,target=/opt/rust/cargo/git,uid=1000,gid=1000 \
     /opt/python/cp310-cp310/bin/python -m build --wheel
 
 RUN auditwheel repair dist/*.whl --wheel-dir dist-repaired/

--- a/ffi.mk
+++ b/ffi.mk
@@ -1,13 +1,13 @@
 
-MANYLINUX_PREFIX=pyroscope/rust_builder
-MANYLINUX_VERSION=4
-BUILD_ARCH_AMD=manylinux2014_x86_64
-BUILD_ARCH_ARM=manylinux2014_aarch64
+REGISTRY ?= ghcr.io/grafana/pyroscope-rs
+BASE_VERSION ?= v1
 
 .phony: wheel/linux/amd64
 wheel/linux/amd64:
 	docker buildx build \
 		--build-arg=PLATFORM=x86_64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 	 	--platform=linux/amd64 \
 	 	--output=. \
 	 	-f docker/wheel.Dockerfile \
@@ -17,6 +17,8 @@ wheel/linux/amd64:
 wheel/linux/arm64:
 	docker buildx build \
 		--build-arg=PLATFORM=aarch64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 	 	--platform=linux/arm64 \
 	 	--output=. \
 	 	-f docker/wheel.Dockerfile \
@@ -26,6 +28,8 @@ wheel/linux/arm64:
 wheel/musllinux/amd64:
 	docker buildx build \
 		--build-arg=PLATFORM=x86_64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 	 	--platform=linux/amd64 \
 	 	--output=. \
 	 	-f docker/wheel-musllinux.Dockerfile \
@@ -35,6 +39,8 @@ wheel/musllinux/amd64:
 wheel/musllinux/arm64:
 	docker buildx build \
 		--build-arg=PLATFORM=aarch64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 	 	--platform=linux/arm64 \
 	 	--output=. \
 	 	-f docker/wheel-musllinux.Dockerfile \
@@ -55,6 +61,8 @@ wheel/mac/arm64:
 gem/linux/amd64:
 	docker buildx build \
 		--build-arg=PLATFORM=x86_64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 		--build-arg="TARGET_TASK=x86_64_linux:gem" \
 		--output=pyroscope_ffi/ruby \
 	 	--platform=linux/amd64 \
@@ -65,6 +73,8 @@ gem/linux/amd64:
 gem/linux/arm64:
 	docker buildx build  \
 		--build-arg=PLATFORM=aarch64 \
+		--build-arg=REGISTRY=$(REGISTRY) \
+		--build-arg=BASE_VERSION=$(BASE_VERSION) \
 		--build-arg="TARGET_TASK=aarch64_linux:gem" \
 		--output=pyroscope_ffi/ruby \
 		--platform=linux/arm64 \


### PR DESCRIPTION
## Summary

Add pre-built Docker base images pushed to GHCR to eliminate repeated toolchain installation on every PR build. Each Docker-based CI job (Python wheels, Ruby gems) currently re-installs system packages, the Rust 1.87 toolchain, and Python build tools from scratch, adding ~2-3 minutes of overhead per job across 5 parallel jobs.

## Changes

**New base Dockerfiles:**
- `docker/base-manylinux.Dockerfile` — shared base for both Python manylinux wheel and Ruby gem Linux builds. Installs system packages, Rust 1.87 to `/opt/rust` (accessible by both root and builder user), creates `builder` user (UID 1000), and installs Python `build` package.
- `docker/base-musllinux.Dockerfile` — base for Python musllinux wheel builds with Alpine packages and musl Rust target.

**New workflow:**
- `.github/workflows/build-base-images.yml` — builds and pushes 4 images (2 types × 2 platforms) to GHCR. Triggers on push to `main` when `docker/base-*.Dockerfile` changes, or via manual `workflow_dispatch`.

**Updated consumer Dockerfiles:**
- `docker/wheel.Dockerfile` — replaced 23 lines of setup with `FROM` referencing the pre-built manylinux base
- `docker/wheel-musllinux.Dockerfile` — same pattern, using the musllinux base
- `docker/gem.Dockerfile` — reuses the manylinux base with `USER root` for the Rust compilation stage (no separate gem base image needed)

**Updated build system:**
- `ffi.mk` — passes `REGISTRY` and `BASE_VERSION` build args to all Docker builds, overridable for forks
- `docker/Makefile` — replaced old Docker Hub targets (which referenced non-existent Dockerfiles) with GHCR base image build/push targets

**Updated CI/release workflows:**
- Added `packages: read` permission and GHCR login step to `ci-ffi-python.yml`, `ci-ffi-ruby.yml`, `release-python.yml`, and `release-ruby.yml`

## Image tags

```
ghcr.io/grafana/pyroscope-rs/builder-manylinux:v1-x86_64
ghcr.io/grafana/pyroscope-rs/builder-manylinux:v1-aarch64
ghcr.io/grafana/pyroscope-rs/builder-musllinux:v1-x86_64
ghcr.io/grafana/pyroscope-rs/builder-musllinux:v1-aarch64
```

## Deployment

After merging, trigger the `build-base-images` workflow via `workflow_dispatch` to push the initial images before any subsequent PR can use them.

## Rust version bump procedure

1. Update `RUST_VERSION` in the two `docker/base-*.Dockerfile` files
2. Bump `BASE_VERSION` (e.g., `v1` → `v2`) in `ffi.mk`, `docker/Makefile`, and consumer Dockerfiles
3. Merge to main — workflow builds new images automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)