### PR TITLE
fix(ci): bump Rust toolchain to 1.88.0 for naked_functions stabilization

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -126,7 +126,7 @@ jobs:
           python-version: "3.10"
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
       - run: python -m pip install build
       - run: python -m build --sdist
       - run: python -m pip install --force-reinstall dist/*.tar.gz
@@ -158,7 +158,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
           targets: ${{ matrix.target }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -68,7 +68,7 @@ jobs:
           ruby-version: '4.0.1'
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
           targets: ${{ matrix.target }}
       - run: make gem/mac/${{ matrix.mk-arch }}
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
           target: ${{ matrix.target }}
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -78,7 +78,7 @@ jobs:
           ruby-version: '4.0.1'
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
           target: ${{ matrix.target }}
 
       - run: make gem/mac/${{ matrix.mk-arch }}

--- a/docker/gem.Dockerfile
+++ b/docker/gem.Dockerfile
@@ -1,7 +1,7 @@
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
 
-ENV RUST_VERSION=1.87
+ENV RUST_VERSION=1.88
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o ./rustup-init \
     && chmod +x ./rustup-init \
     && ./rustup-init  -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -11,7 +11,7 @@ RUN adduser -D builder \
 USER builder
 RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
 
-ENV RUST_VERSION=1.87
+ENV RUST_VERSION=1.88
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
     && chmod +x /tmp/rustup-init \
     && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-musl \

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -m builder \
 USER builder
 RUN test "$(id -u)" = "1000" || { echo "ERROR: builder uid is $(id -u), expected 1000"; exit 1; }
 
-ENV RUST_VERSION=1.87
+ENV RUST_VERSION=1.88
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o /tmp/rustup-init \
     && chmod +x /tmp/rustup-init \
     && /tmp/rustup-init -y --default-toolchain=${RUST_VERSION} --default-host=$(arch)-unknown-linux-gnu \


### PR DESCRIPTION
## Summary

- Bump pinned Rust toolchain from 1.85.0/1.87.0 to 1.88.0 across all CI workflows and Dockerfiles

## Why

All Python and Ruby build jobs fail with:

```
error[E0658]: use of unstable library feature `naked_functions`
error: `naked` is not an unsafe attribute
```

The `kindasafe` crate uses `#[unsafe(naked)]` and `naked_asm!`, which were stabilized in **Rust 1.88.0**. CI was using older toolchains (1.85.0 for macOS/crates.io, 1.87.0 for Docker builds) that don't support this.

## Changes

**CI Workflows** (5 files):
- `ci-ffi-python.yml` — sdist job (1.87.0 → 1.88.0), macOS job (1.85.0 → 1.88.0)
- `ci-ffi-ruby.yml` — macOS job (1.85.0 → 1.88.0)
- `release-python.yml` — macOS release job (1.85.0 → 1.88.0)
- `release-ruby.yml` — macOS release job (1.85.0 → 1.88.0)
- `publish-rust-crate.yml` — crates.io publish job (1.85.0 → 1.88.0)

**Dockerfiles** (3 files):
- `docker/wheel.Dockerfile` — `RUST_VERSION=1.87` → `1.88`
- `docker/wheel-musllinux.Dockerfile` — `RUST_VERSION=1.87` → `1.88`
- `docker/gem.Dockerfile` — `RUST_VERSION=1.87` → `1.88`

No code changes needed — the `kindasafe` code already uses the correct stabilized syntax.

## Test plan

- [ ] All CI build jobs pass (manylinux, musllinux, macOS, sdist)
- [ ] Clippy passes with `--deny warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)