### PR TITLE
feat: split kindasafe into no_std read crate and kindasafe_init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,6 +1342,16 @@ name = "kindasafe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "kindasafe_init",
+ "libc",
+]
+
+[[package]]
+name = "kindasafe_init"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kindasafe",
  "libc",
  "spin",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "pyroscope_ffi/ruby/ext/rbspy",
     "pyroscope_ffi/python/rust",
     "kit/kindasafe",
+    "kit/kindasafe_init",
 ]
 
 [workspace.dependencies]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,8 @@ include Cargo.toml
 include Cargo.lock
 include pyroscope_ffi/python/rust/Cargo.toml
 include pyroscope_ffi/ruby/ext/rbspy/Cargo.toml
-include kit/kindasafe/Cargo.toml
 recursive-include src *.rs
 recursive-include pyroscope_ffi/python/rust/src/ *.rs
 recursive-include pyroscope_ffi/ruby/ext/rbspy/src/ *.rs
-recursive-include kit/kindasafe/src/ *.rs
+recursive-include kit/ *.rs
+recursive-include kit/ Cargo.toml

--- a/kit/kindasafe/Cargo.toml
+++ b/kit/kindasafe/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-libc =  {version = "0.2.182"}
-spin =  {version="0.10.0"}
+
 [dev-dependencies]
 anyhow = "=1.0.102"
 libc = "=0.2.182"
+kindasafe_init = { path = "../kindasafe_init" }

--- a/kit/kindasafe/src/lib.rs
+++ b/kit/kindasafe/src/lib.rs
@@ -1,7 +1,5 @@
-#[derive(Debug, PartialEq, Clone)]
-pub enum InitError {
-    InstallSignalHandlersFailed,
-}
+#![cfg(target_arch = "x86_64")]
+#![no_std]
 
 #[derive(Debug, PartialEq)]
 pub struct ReadMemError {
@@ -39,7 +37,7 @@ pub fn str(buf: &mut [u8], at: Ptr) -> Result<&str, ReadMemError> {
     for i in 0..buf.len() {
         if buf[i] == 0 {
             let v = &buf[..i];
-            return match str::from_utf8(v) {
+            return match core::str::from_utf8(v) {
                 Ok(v) => Ok(v),
                 Err(_) => Err(ReadMemError { signal: 228 }), //todo
             };
@@ -143,117 +141,4 @@ pub mod arch {
             ],
         }
     }
-
-    /// # Safety
-    /// `data` must be a valid pointer to `libc::ucontext_t`.
-    pub unsafe fn crash_handler(
-        sig: core::ffi::c_int,
-        info: *const core::ffi::c_void,
-        data: *mut core::ffi::c_void,
-    ) {
-        unsafe {
-            let ctx: *mut libc::ucontext_t = data as *mut libc::ucontext_t;
-            let pc = (*ctx).uc_mcontext.gregs[libc::REG_RIP as usize] as usize;
-            for x in crash_points().crash_points {
-                if x.pc == pc {
-                    (*ctx).uc_mcontext.gregs[libc::REG_RIP as usize] =
-                        (pc + x.skip) as libc::greg_t;
-                    (*ctx).uc_mcontext.gregs[x.signal_reg] = sig as u64 as libc::greg_t;
-                    return;
-                }
-            }
-            super::fallback(sig, info, data);
-        }
-    }
-}
-
-// todo think how to have less static mut
-static mut FALLBACK_SIGSEGV: libc::sigaction = unsafe { core::mem::zeroed() };
-static mut FALLBACK_SIGBUS: libc::sigaction = unsafe { core::mem::zeroed() };
-
-static INIT_LOCK: spin::Mutex<Option<Result<(), InitError>>> = spin::Mutex::new(None);
-
-pub fn is_initialized() -> Option<Result<(), InitError>> {
-    let g = INIT_LOCK.lock();
-    g.clone()
-}
-pub fn init() -> Result<(), InitError> {
-    let mut g = INIT_LOCK.lock();
-    if let Some(prev) = g.clone() {
-        return prev;
-    }
-
-    let res = init_locked();
-    *g = Some(res.clone());
-    res
-}
-
-pub fn init_locked() -> Result<(), InitError> {
-    unsafe {
-        FALLBACK_SIGSEGV = new_signal_handler(libc::SIGSEGV, arch::crash_handler)
-            .map_err(|_| InitError::InstallSignalHandlersFailed)?;
-        FALLBACK_SIGBUS = new_signal_handler(libc::SIGBUS, arch::crash_handler)
-            .map_err(|_| InitError::InstallSignalHandlersFailed)?;
-    }
-    Ok(())
-}
-
-fn call_fallback(
-    sig: core::ffi::c_int,
-    info: *const core::ffi::c_void,
-    data: *mut core::ffi::c_void,
-    fallback: libc::sigaction,
-) {
-    if fallback.sa_sigaction == 0 {
-        restore_default_ignal_handler(sig);
-    } else {
-        let handler = unsafe {
-            core::mem::transmute::<
-                usize,
-                extern "C" fn(core::ffi::c_int, *const core::ffi::c_void, *mut core::ffi::c_void),
-            >(fallback.sa_sigaction)
-        };
-        handler(sig, info, data);
-    }
-}
-unsafe fn fallback(
-    sig: core::ffi::c_int,
-    info: *const core::ffi::c_void,
-    data: *mut core::ffi::c_void,
-) {
-    if sig == libc::SIGSEGV {
-        call_fallback(sig, info, data, unsafe { FALLBACK_SIGSEGV });
-        return;
-    }
-    if sig == libc::SIGBUS {
-        call_fallback(sig, info, data, unsafe { FALLBACK_SIGBUS });
-    }
-}
-
-fn new_signal_handler(
-    signal: core::ffi::c_int,
-    handler: unsafe fn(
-        sig: core::ffi::c_int,
-        info: *const core::ffi::c_void,
-        data: *mut core::ffi::c_void,
-    ),
-) -> Result<libc::sigaction, ()> {
-    unsafe {
-        let mut old: libc::sigaction = core::mem::zeroed();
-        if libc::sigaction(signal, core::ptr::null_mut(), &mut old) != 0 {
-            return Err(());
-        }
-        let mut new: libc::sigaction = old;
-        new.sa_sigaction = handler as usize;
-        new.sa_flags |= libc::SA_RESTART | libc::SA_SIGINFO;
-        if libc::sigaction(signal, &new, &mut old) != 0 {
-            return Err(());
-        }
-        Ok(old)
-    }
-}
-
-pub fn restore_default_ignal_handler(sig: core::ffi::c_int) {
-    let action: libc::sigaction = unsafe { core::mem::zeroed() };
-    unsafe { libc::sigaction(sig, &action, core::ptr::null_mut()) };
 }

--- a/kit/kindasafe/tests/positive.rs
+++ b/kit/kindasafe/tests/positive.rs
@@ -6,14 +6,14 @@ use kindasafe::{Ptr, slice, u64};
 
 #[test]
 fn test_init() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     Ok(())
 }
 
 #[test]
 fn u64_aligned() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
 
     let x: Vec<u8> = vec![0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef];
     let x_ptr = x.as_ptr() as Ptr;
@@ -25,7 +25,7 @@ fn u64_aligned() -> Result<(), anyhow::Error> {
 
 #[test]
 fn u64_unaligned() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
 
     let x: Vec<u8> = vec![0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef, 0x00];
     let x_ptr = x.as_ptr() as Ptr + 1;
@@ -36,7 +36,7 @@ fn u64_unaligned() -> Result<(), anyhow::Error> {
 
 #[test]
 fn u64_sigsegv() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     trigger_sigsegv(|p| {
         assert_eq!(
             u64(p),
@@ -50,7 +50,7 @@ fn u64_sigsegv() -> Result<(), anyhow::Error> {
 
 #[test]
 fn u64_sigbus() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     trigger_sigbus(|p| {
         assert_eq!(
             u64(p),
@@ -64,7 +64,7 @@ fn u64_sigbus() -> Result<(), anyhow::Error> {
 
 #[test]
 fn u64_unaligned_page_boundary() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
 
     trigger_sigsegv_page_boundary(|p| {
         assert_eq!(u64(p), Ok(0x6161616161616161));
@@ -87,7 +87,7 @@ fn u64_unaligned_page_boundary() -> Result<(), anyhow::Error> {
 
 #[test]
 fn vec_aligned() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     let mut buf = vec![0u8; 8];
     let x: Vec<u8> = vec![0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef];
     slice(&mut buf, x.as_ptr() as Ptr).map_err(|err| anyhow!("read mem error {err:?}"))?;
@@ -97,7 +97,7 @@ fn vec_aligned() -> Result<(), anyhow::Error> {
 
 #[test]
 fn vec_unaligned() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     let mut buf = vec![0u8; 8];
     let x: Vec<u8> = vec![0xca, 0xfe, 0xba, 0xbe, 0xde, 0xad, 0xbe, 0xef, 0xcc];
     let x_ptr = x.as_ptr() as Ptr + 1;
@@ -109,7 +109,7 @@ fn vec_unaligned() -> Result<(), anyhow::Error> {
 
 #[test]
 fn vec_sigsegv() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     trigger_sigsegv(|p| {
         let mut buf = [0u8; 8];
         let res = slice(&mut buf, p as Ptr);
@@ -125,7 +125,7 @@ fn vec_sigsegv() -> Result<(), anyhow::Error> {
 
 #[test]
 fn vec_sigbus() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     trigger_sigbus(|p| {
         let mut buf = [0u8; 8];
         let res = slice(&mut buf, p as Ptr);
@@ -140,7 +140,7 @@ fn vec_sigbus() -> Result<(), anyhow::Error> {
 }
 #[test]
 fn vec_sigsegv_page_boundary() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
 
     trigger_sigsegv_page_boundary(|p| {
         let mut buf = [0u8; 16];
@@ -166,7 +166,7 @@ fn vec_sigsegv_page_boundary() -> Result<(), anyhow::Error> {
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[test]
 fn fs_0x10() -> Result<(), anyhow::Error> {
-    kindasafe::init().map_err(|err| anyhow!("{:?}", err))?;
+    kindasafe_init::init().map_err(|err| anyhow!("{:?}", err))?;
     let res = kindasafe::arch::fs_0x10();
     assert_eq!(0, res.signal);
     assert_ne!(0, res.value);

--- a/kit/kindasafe_init/Cargo.toml
+++ b/kit/kindasafe_init/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kindasafe_init"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+kindasafe = { path = "../kindasafe" }
+libc = { version = "0.2.182" }
+spin = { version = "0.10.0" }
+
+[dev-dependencies]
+anyhow = "=1.0.102"

--- a/kit/kindasafe_init/src/lib.rs
+++ b/kit/kindasafe_init/src/lib.rs
@@ -1,0 +1,170 @@
+#![cfg(target_arch = "x86_64")]
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum InitError {
+    InstallSignalHandlersFailed,
+    SanityCheckFailed,
+}
+
+// todo think how to have less static mut
+static mut FALLBACK_SIGSEGV: libc::sigaction = unsafe { core::mem::zeroed() };
+static mut FALLBACK_SIGBUS: libc::sigaction = unsafe { core::mem::zeroed() };
+
+static INIT_LOCK: spin::Mutex<Option<Result<(), InitError>>> = spin::Mutex::new(None);
+
+pub fn is_initialized() -> Option<Result<(), InitError>> {
+    let g = INIT_LOCK.lock();
+    g.clone()
+}
+pub fn init() -> Result<(), InitError> {
+    let mut g = INIT_LOCK.lock();
+    if let Some(prev) = g.clone() {
+        return prev;
+    }
+
+    let res = init_locked();
+    *g = Some(res.clone());
+    res
+}
+
+pub fn init_locked() -> Result<(), InitError> {
+    unsafe {
+        FALLBACK_SIGSEGV = new_signal_handler(libc::SIGSEGV, crash_handler)
+            .map_err(|_| InitError::InstallSignalHandlersFailed)?;
+        FALLBACK_SIGBUS = new_signal_handler(libc::SIGBUS, crash_handler)
+            .map_err(|_| InitError::InstallSignalHandlersFailed)?;
+    }
+    Ok(())
+}
+
+/// # Safety
+/// `data` must be a valid pointer to `libc::ucontext_t`.
+#[cfg(target_arch = "x86_64")]
+pub unsafe fn crash_handler(
+    sig: core::ffi::c_int,
+    info: *const core::ffi::c_void,
+    data: *mut core::ffi::c_void,
+) {
+    unsafe {
+        let ctx: *mut libc::ucontext_t = data as *mut libc::ucontext_t;
+        let pc = (*ctx).uc_mcontext.gregs[libc::REG_RIP as usize] as usize;
+        for x in kindasafe::arch::crash_points().crash_points {
+            if x.pc == pc {
+                (*ctx).uc_mcontext.gregs[libc::REG_RIP as usize] = (pc + x.skip) as libc::greg_t;
+                (*ctx).uc_mcontext.gregs[x.signal_reg] = sig as u64 as libc::greg_t;
+                return;
+            }
+        }
+        fallback(sig, info, data);
+    }
+}
+
+fn call_fallback(
+    sig: core::ffi::c_int,
+    info: *const core::ffi::c_void,
+    data: *mut core::ffi::c_void,
+    fallback: libc::sigaction,
+) {
+    if fallback.sa_sigaction == 0 {
+        restore_default_ignal_handler(sig);
+    } else {
+        let handler = unsafe {
+            core::mem::transmute::<
+                usize,
+                extern "C" fn(core::ffi::c_int, *const core::ffi::c_void, *mut core::ffi::c_void),
+            >(fallback.sa_sigaction)
+        };
+        handler(sig, info, data);
+    }
+}
+unsafe fn fallback(
+    sig: core::ffi::c_int,
+    info: *const core::ffi::c_void,
+    data: *mut core::ffi::c_void,
+) {
+    if sig == libc::SIGSEGV {
+        call_fallback(sig, info, data, unsafe { FALLBACK_SIGSEGV });
+        return;
+    }
+    if sig == libc::SIGBUS {
+        call_fallback(sig, info, data, unsafe { FALLBACK_SIGBUS });
+    }
+}
+
+fn new_signal_handler(
+    signal: core::ffi::c_int,
+    handler: unsafe fn(
+        sig: core::ffi::c_int,
+        info: *const core::ffi::c_void,
+        data: *mut core::ffi::c_void,
+    ),
+) -> Result<libc::sigaction, ()> {
+    unsafe {
+        let mut old: libc::sigaction = core::mem::zeroed();
+        if libc::sigaction(signal, core::ptr::null_mut(), &mut old) != 0 {
+            return Err(());
+        }
+        let mut new: libc::sigaction = old;
+        new.sa_sigaction = handler as usize;
+        new.sa_flags |= libc::SA_RESTART | libc::SA_SIGINFO;
+        if libc::sigaction(signal, &new, &mut old) != 0 {
+            return Err(());
+        }
+        Ok(old)
+    }
+}
+
+pub fn restore_default_ignal_handler(sig: core::ffi::c_int) {
+    let action: libc::sigaction = unsafe { core::mem::zeroed() };
+    unsafe { libc::sigaction(sig, &action, core::ptr::null_mut()) };
+}
+
+/// Sanity check that kindasafe crash recovery is working.
+///
+/// Maps a PROT_NONE page, attempts to read it via `kindasafe::u64`,
+/// and verifies the read returns an error (SIGSEGV) instead of crashing.
+/// Unmaps the page before returning.
+///
+/// Returns `Ok(())` if the sanity check passes, `Err(SanityCheckFailed)` if
+/// the read unexpectedly succeeded (meaning crash recovery is broken).
+pub fn sanity_check() -> Result<(), InitError> {
+    unsafe {
+        let page = libc::mmap(
+            core::ptr::null_mut(),
+            4096,
+            libc::PROT_NONE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        );
+        if page == libc::MAP_FAILED {
+            return Err(InitError::SanityCheckFailed);
+        }
+        let addr = page as u64;
+        let result = kindasafe::u64(addr);
+        libc::munmap(page, 4096);
+        match result {
+            Err(_) => Ok(()),
+            Ok(_) => Err(InitError::SanityCheckFailed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_init_idempotent() {
+        assert!(init().is_ok());
+        assert!(init().is_ok());
+        assert!(is_initialized().is_some());
+        assert_eq!(is_initialized(), Some(Ok(())));
+    }
+
+    #[test]
+    fn test_sanity_check() {
+        assert!(init().is_ok());
+        assert!(sanity_check().is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

- Split `kindasafe` into two crates so signal-handler-path code can depend on lightweight read primitives without pulling in `libc`
- `kindasafe` is now `#![no_std]` with zero production dependencies — contains only naked-asm memory read primitives (`u64`, `slice`, `str`, `fs_0x10`) and `CrashPoint` types
- New `kindasafe_init` crate depends on `kindasafe` + `libc` + `spin` and contains all initialization and signal handler orchestration (`init`, `crash_handler`, fallback chaining, `sanity_check`)

## Test plan

- [x] `cargo build -p kindasafe` — builds with no_std, no prod dependencies
- [x] `cargo build -p kindasafe_init` — builds with libc+spin
- [x] `cargo test -p kindasafe` — all 13 tests pass (including fs_0x10)
- [x] `cargo test -p kindasafe_init` — init idempotency and sanity_check tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)