### PR TITLE
chore: add Renovate config for OpenSSL and downgrade to 3.5.4 to test

### DIFF
--- a/docker/gem.Dockerfile
+++ b/docker/gem.Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 ENV RUST_VERSION=1.88
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o ./rustup-init \

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/musllinux_1_2_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 RUN apk add --no-cache gcc musl-dev libffi-dev make perl linux-headers
 

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 RUN yum -y install gcc libffi-devel perl-core glibc-devel make
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchDepNames": ["openssl/openssl"],
+      "separateMinorPatch": true
+    },
+    {
+      "matchDepNames": ["openssl/openssl"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^docker/.*\\.Dockerfile$"],
+      "matchStrings": ["ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "openssl/openssl",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^openssl-(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Renovate configuration to automatically track OpenSSL patch releases in pyroscope-rs Dockerfiles. OpenSSL is pinned intentionally to 3.5.4 (one patch behind latest 3.5.5) to verify Renovate detects the outdated version and opens a PR to bump it.

## Changes

- **`renovate.json`** (new): Custom regex manager that scans `docker/*.Dockerfile` for `ARG OPENSSL_VERSION=<version>`, tracks `openssl/openssl` GitHub releases, and only enables patch-level updates (major/minor disabled)
- **`docker/wheel.Dockerfile`**, **`docker/wheel-musllinux.Dockerfile`**, **`docker/gem.Dockerfile`**: Downgrade `OPENSSL_VERSION` from 3.5.5 to 3.5.4

## Why

Following the same pattern used in [pyroscope-dotnet](https://github.com/grafana/pyroscope-dotnet/blob/main/renovate.json), this ensures OpenSSL patch updates are automated. The intentional downgrade to 3.5.4 serves as a test — once merged, Renovate should detect the outdated version and open a PR to bump all three Dockerfiles back to 3.5.5.

## Implementation details

- `fileMatch: ["^docker/.*\\.Dockerfile$"]` covers all three build Dockerfiles
- `extractVersionTemplate: "^openssl-(?<version>.*)$"` strips the `openssl-` prefix from GitHub release tags to match the `X.Y.Z` format used in the `ARG`
- `separateMinorPatch: true` + major/minor disabled = only patch bumps are proposed automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)