### PR TITLE
chore(deps): Revert update dependency openssl/openssl to v3.5.5 (#428)"

### DIFF
--- a/docker/gem.Dockerfile
+++ b/docker/gem.Dockerfile
@@ -1,6 +1,6 @@
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 ENV RUST_VERSION=1.88
 RUN curl https://static.rust-lang.org/rustup/dist/$(arch)-unknown-linux-musl/rustup-init -o ./rustup-init \

--- a/docker/wheel-musllinux.Dockerfile
+++ b/docker/wheel-musllinux.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/musllinux_1_2_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 RUN apk add --no-cache gcc musl-dev libffi-dev make perl linux-headers
 

--- a/docker/wheel.Dockerfile
+++ b/docker/wheel.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.22@sha256:4a43a54dd1fedceb30ba47e76cfcf2b47304f4161c0caeac2db1c61804ea3c91
 ARG PLATFORM=x86_64
 FROM quay.io/pypa/manylinux2014_${PLATFORM} AS builder
-ARG OPENSSL_VERSION=3.5.5
+ARG OPENSSL_VERSION=3.5.4
 
 RUN yum -y install gcc libffi-devel perl-core glibc-devel make
 


### PR DESCRIPTION
## Summary

- Reverts commit 3ebdee9126011b4b23d4225c54979060900e88d8 which bumped OpenSSL from 3.5.4 to 3.5.5
- Downgrades `OPENSSL_VERSION` back to `3.5.4` in all three Docker build files:
  - `docker/gem.Dockerfile`
  - `docker/wheel.Dockerfile`
  - `docker/wheel-musllinux.Dockerfile`

## Why

Rolling back the OpenSSL 3.5.5 dependency update to restore the previous 3.5.4 version used for building Python wheels, musllinux wheels, and Ruby gems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)