### PR TITLE
fix(ci): make job keys and display names unique across FFI workflows

### DIFF
--- a/.github/workflows/ci-ffi-python.yml
+++ b/.github/workflows/ci-ffi-python.yml
@@ -29,7 +29,7 @@ jobs:
       - run: make ffi/python/header ffi/python/cffi
       - run: git diff --exit-code
 
-  linux-build:
+  python-linux-build:
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +46,7 @@ jobs:
           - name: musllinux-arm64
             runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-arm64-large' || 'ubuntu-24.04-arm' }}
             make-target: wheel/musllinux/arm64
-    name: Linux Build - ${{ matrix.name }}
+    name: Python Linux Build - ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
 
     steps:
@@ -68,7 +68,7 @@ jobs:
           name: "${{ matrix.name }}.whl"
           path: dist/*
 
-  linux-test:
+  python-linux-test:
     strategy:
       fail-fast: false
       matrix:
@@ -106,8 +106,8 @@ jobs:
             PYTHON_VERSION: "3.10"
           - variant: musllinux-arm64
             PYTHON_VERSION: "3.11"
-    needs: ["linux-build"]
-    name: Linux Test - ${{ matrix.variant }} - ${{ matrix.PYTHON_VERSION }}
+    needs: ["python-linux-build"]
+    name: Python Linux Test - ${{ matrix.variant }} - ${{ matrix.PYTHON_VERSION }}
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -150,7 +150,7 @@ jobs:
           name: "sdist.whl"
           path: dist/*
 
-  macos-build:
+  python-macos-build:
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +162,7 @@ jobs:
             target: aarch64-apple-darwin
             mk-arch: arm64
 
-    name: macOS - ${{ matrix.target }}
+    name: Python macOS - ${{ matrix.target }}
     runs-on: macos-${{ matrix.macos-version }}
 
     steps:

--- a/.github/workflows/ci-ffi-ruby.yml
+++ b/.github/workflows/ci-ffi-ruby.yml
@@ -25,8 +25,8 @@ jobs:
       - run: make ffi/ruby/header
       - run: git diff --exit-code
 
-  linux-build:
-    name: Build linux gem amd64
+  ruby-linux-build:
+    name: Ruby Linux Build
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
 
     steps:
@@ -41,7 +41,7 @@ jobs:
         with:
           name: "linux.gem"
           path: pyroscope_ffi/ruby/pkg/*.gem
-  macos-build:
+  ruby-macos-build:
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +53,7 @@ jobs:
             target: aarch64-apple-darwin
             mk-arch: arm64
 
-    name: macOS - ${{ matrix.target }}
+    name: Ruby macOS - ${{ matrix.target }}
     runs-on: macos-${{ matrix.macos-version }}
 
     env:
@@ -76,14 +76,14 @@ jobs:
           name: ${{ github.sha }}-ruby-${{ matrix.target }}
           path: pyroscope_ffi/ruby/pkg/*.gem
 
-  linux-test:
+  ruby-linux-test:
     strategy:
       fail-fast: false
       matrix:
         PYROSCOPE_ONCPU: [1, 0]
         RUBY_VERSION: ["3.1", "3.2", "3.3", "3.3.8", "3.4.3", "3.4.6"]
-    needs: ["linux-build"]
-    name: Linux Test
+    needs: ["ruby-linux-build"]
+    name: Ruby Linux Test - oncpu=${{ matrix.PYROSCOPE_ONCPU }} - ${{ matrix.RUBY_VERSION }}
     runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
     steps:
       - uses: ruby/setup-ruby@19a43a6a2428d455dbd1b85344698725179c9d8c # v1.289.0


### PR DESCRIPTION
## Summary

The Python (`ci-ffi-python.yml`) and Ruby (`ci-ffi-ruby.yml`) CI workflows shared identical job keys (`linux-build`, `linux-test`, `macos-build`), making it difficult to configure branch protection required status checks unambiguously.

This PR prefixes all shared job keys and display names with `python-`/`ruby-` so each job is uniquely identifiable:

| Workflow | Old job key | New job key | New display name |
|---|---|---|---|
| Python | `linux-build` | `python-linux-build` | `Python Linux Build - <variant>` |
| Python | `linux-test` | `python-linux-test` | `Python Linux Test - <variant> - <version>` |
| Python | `macos-build` | `python-macos-build` | `Python macOS - <target>` |
| Ruby | `linux-build` | `ruby-linux-build` | `Ruby Linux Build` |
| Ruby | `linux-test` | `ruby-linux-test` | `Ruby Linux Test - oncpu=<0\|1> - <version>` |
| Ruby | `macos-build` | `ruby-macos-build` | `Ruby macOS - <target>` |

Also fixes a bug where the Ruby `linux-test` job used a bare `name: Linux Test` with no matrix variables, so all 12 matrix combinations (2 oncpu values × 6 Ruby versions) displayed the same name in the GitHub UI.

## Why

Branch protection required status checks reference jobs by their context string. Duplicate job keys across workflows made it ambiguous which job was being referenced. With unique keys and names, configuring required checks is straightforward.

## Test plan

- [ ] Verify CI runs successfully on this PR with the renamed jobs
- [ ] Confirm the GitHub Checks tab shows the new prefixed display names
- [ ] After merge, configure branch protection with the unique context strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)