### PR TITLE
fix(jemalloc): use try_lock() in initialize() to avoid panic in async context

### DIFF
--- a/src/backend/jemalloc.rs
+++ b/src/backend/jemalloc.rs
@@ -46,7 +46,12 @@ impl Backend for Jemalloc {
                 "jemalloc: PROF_CTL not available. Ensure jemalloc is configured with prof:true",
             )
         })?;
-        let guard = prof_ctl.blocking_lock();
+        let guard = prof_ctl.try_lock().map_err(|_| {
+            PyroscopeError::new(
+                "jemalloc: failed to acquire PROF_CTL lock during initialization. \
+                 This is unexpected at startup; ensure no other code holds the lock.",
+            )
+        })?;
         if !guard.activated() {
             return Err(PyroscopeError::new(
                 "jemalloc: profiling is not activated. Ensure malloc_conf includes prof:true,prof_active:true",


### PR DESCRIPTION
## Summary

- Replace `blocking_lock()` with `try_lock()` in `Jemalloc::initialize()` to prevent a panic when `PyroscopeAgent::build()` is called from a tokio async context (e.g. `#[tokio::main] async fn main()`)
- `report()` retains `blocking_lock()` since it runs safely in a dedicated `std::thread`

## Problem

`tokio::sync::Mutex::blocking_lock()` panics when called within an async execution context. Since `PyroscopeAgent::build()` is a synchronous method that users call directly — commonly from inside a tokio runtime — the `blocking_lock()` call in `Jemalloc::initialize()` turns a recoverable initialization check into a process-level panic, crashing production async apps at startup.

## Solution

Use `try_lock()` instead of `blocking_lock()` in `initialize()`. This is safe because:

- `initialize()` runs once at startup before the agent thread is spawned, so there is no lock contention
- `try_lock()` works correctly in both sync and async contexts (no panic risk)
- If the lock cannot be acquired, a descriptive `Result::Err` is returned instead of panicking

The `report()` method keeps `blocking_lock()` because it executes inside `std::thread::spawn` (a plain OS thread), where blocking is safe and guaranteed lock acquisition is preferred.

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- [x] All kit tests pass (76 tests, 0 failures)