### PR TITLE
feat: replace raw_pprof on Report with ReportData enum on ReportBatch

### DIFF
--- a/pyroscope_ffi/python/rust/src/backend.rs
+++ b/pyroscope_ffi/python/rust/src/backend.rs
@@ -1,8 +1,8 @@
 use py_spy::sampler::Sampler;
 use pyroscope::{
     backend::{
-        Backend, BackendConfig, Report, ReportBatch, StackBuffer, StackFrame, StackTrace,
-        ThreadTag, ThreadTagsSet,
+        Backend, BackendConfig, Report, ReportBatch, ReportData, StackBuffer, StackFrame,
+        StackTrace, ThreadTag, ThreadTagsSet,
     },
     error::{PyroscopeError, Result},
 };
@@ -131,7 +131,7 @@ impl Backend for Pyspy {
 
         Ok(ReportBatch {
             profile_type: "process_cpu".into(),
-            reports,
+            data: ReportData::Reports(reports),
         })
     }
 }

--- a/pyroscope_ffi/ruby/ext/rbspy/src/backend.rs
+++ b/pyroscope_ffi/ruby/ext/rbspy/src/backend.rs
@@ -1,7 +1,7 @@
 use pyroscope::{
     backend::{
-        Backend, BackendConfig, Report, ReportBatch, StackBuffer, StackFrame, StackTrace,
-        ThreadTag, ThreadTagsSet,
+        Backend, BackendConfig, Report, ReportBatch, ReportData, StackBuffer, StackFrame,
+        StackTrace, ThreadTag, ThreadTagsSet,
     },
     error::{PyroscopeError, Result},
 };
@@ -134,7 +134,7 @@ impl Backend for Rbspy {
 
         Ok(ReportBatch {
             profile_type: "process_cpu".into(),
-            reports,
+            data: ReportData::Reports(reports),
         })
     }
 }

--- a/src/backend/jemalloc.rs
+++ b/src/backend/jemalloc.rs
@@ -1,4 +1,6 @@
-use crate::backend::{Backend, BackendImpl, BackendUninitialized, Report, ReportBatch, ThreadTag};
+use crate::backend::{
+    Backend, BackendImpl, BackendUninitialized, ReportBatch, ReportData, ThreadTag,
+};
 use crate::error::{PyroscopeError, Result};
 
 const LOG_TAG: &str = "Pyroscope::Jemalloc";
@@ -74,7 +76,7 @@ impl Backend for Jemalloc {
 
         Ok(ReportBatch {
             profile_type: "memory".into(),
-            reports: vec![Report::from_raw_pprof(pprof_data)],
+            data: ReportData::RawPprof(pprof_data),
         })
     }
 

--- a/src/backend/pprof.rs
+++ b/src/backend/pprof.rs
@@ -1,6 +1,6 @@
 use crate::backend::{
-    Backend, BackendConfig, BackendImpl, BackendUninitialized, Report, ReportBatch, StackBuffer,
-    StackFrame, StackTrace, ThreadTag, ThreadTagsSet,
+    Backend, BackendConfig, BackendImpl, BackendUninitialized, Report, ReportBatch, ReportData,
+    StackBuffer, StackFrame, StackTrace, ThreadTag, ThreadTagsSet,
 };
 use crate::error::{PyroscopeError, Result};
 use pprof::{ProfilerGuard, ProfilerGuardBuilder};
@@ -97,7 +97,7 @@ impl Backend for Pprof<'_> {
 
         Ok(ReportBatch {
             profile_type: "process_cpu".into(),
-            reports,
+            data: ReportData::Reports(reports),
         })
     }
 

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -108,13 +108,25 @@ impl Metadata {
     }
 }
 
+/// The payload of a report batch: either structured stack-trace reports
+/// (which will be encoded into pprof by the session layer) or pre-encoded
+/// pprof bytes produced directly by a backend (e.g. jemalloc).
+#[derive(Debug, Clone)]
+pub enum ReportData {
+    /// Structured stack-trace reports that must be pprof-encoded before sending.
+    Reports(Vec<Report>),
+    /// Pre-encoded pprof bytes (may already be gzipped). Used by backends
+    /// like jemalloc that produce a complete pprof profile directly.
+    RawPprof(Vec<u8>),
+}
+
 /// A batch of reports with a shared profile type.
 #[derive(Debug, Clone)]
 pub struct ReportBatch {
     /// Profile type name (e.g. "process_cpu", "memory")
     pub profile_type: String,
-    /// Reports in this batch
-    pub reports: Vec<Report>,
+    /// Report data in this batch
+    pub data: ReportData,
 }
 
 /// Report
@@ -124,8 +136,6 @@ pub struct Report {
     pub data: HashMap<StackTrace, usize>,
     /// Metadata
     pub metadata: Metadata,
-    /// Pre-encoded pprof bytes, may be gzipped (used by backends like jemalloc that produce pprof directly)
-    pub raw_pprof: Option<Vec<u8>>,
 }
 
 /// Custom implementation of the Hash trait for Report.
@@ -142,16 +152,6 @@ impl Report {
         Self {
             data,
             metadata: Metadata::default(),
-            raw_pprof: None,
-        }
-    }
-
-    /// Create a Report from pre-encoded pprof bytes (may be gzipped).
-    pub fn from_raw_pprof(pprof_data: Vec<u8>) -> Self {
-        Self {
-            data: HashMap::new(),
-            metadata: Metadata::default(),
-            raw_pprof: Some(pprof_data),
         }
     }
 
@@ -165,7 +165,6 @@ impl Report {
         Self {
             data: self.data,
             metadata,
-            raw_pprof: self.raw_pprof,
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,7 +8,7 @@ use std::{
 use crate::encode::gen::push::{PushRequest, RawProfileSeries, RawSample};
 use crate::encode::gen::types::LabelPair;
 use crate::{
-    backend::{Report, ReportBatch},
+    backend::{Report, ReportBatch, ReportData},
     encode::pprof,
     pyroscope::PyroscopeConfig,
     utils::get_time_range,
@@ -125,43 +125,32 @@ impl Session {
     fn push(self, client: &reqwest::blocking::Client) -> Result<()> {
         log::info!(target: LOG_TAG, "Sending Session: {} - {}", self.from, self.until);
 
-        let ReportBatch {
-            profile_type,
-            reports,
-        } = self.batch;
+        let ReportBatch { profile_type, data } = self.batch;
 
-        let has_raw_pprof = reports.first().and_then(|r| r.raw_pprof.as_ref()).is_some();
-
-        let raw_profile = if has_raw_pprof {
-            debug_assert!(
-                reports.len() == 1,
-                "raw_pprof path expects exactly one report"
-            );
-            if self.config.func.is_some() {
-                log::warn!(target: LOG_TAG, "report transform function is not supported with raw pprof backends (e.g. jemalloc)");
-            }
-            // Backends like jemalloc produce a complete pprof profile (may be gzipped).
-            // Pass it through directly — Pyroscope accepts both compressed and uncompressed pprof.
-            reports
-                .into_iter()
-                .find_map(|r| r.raw_pprof)
-                .unwrap_or_default()
-        } else {
-            let transformed: Vec<Report>;
-            let encode_input = match self.config.func {
-                None => &reports,
-                Some(f) => {
-                    transformed = reports.iter().map(|r| f(r.to_owned())).collect();
-                    &transformed
+        let raw_profile = match data {
+            ReportData::RawPprof(pprof_bytes) => {
+                if self.config.func.is_some() {
+                    log::warn!(target: LOG_TAG, "report transform function is not supported with raw pprof backends (e.g. jemalloc)");
                 }
-            };
-            pprof::encode(
-                encode_input,
-                self.config.sample_rate,
-                self.from * 1_000_000_000,
-                (self.until - self.from) * 1_000_000_000,
-            )
-            .encode_to_vec()
+                pprof_bytes
+            }
+            ReportData::Reports(reports) => {
+                let transformed: Vec<Report>;
+                let encode_input = match self.config.func {
+                    None => &reports,
+                    Some(f) => {
+                        transformed = reports.iter().map(|r| f(r.to_owned())).collect();
+                        &transformed
+                    }
+                };
+                pprof::encode(
+                    encode_input,
+                    self.config.sample_rate,
+                    self.from * 1_000_000_000,
+                    (self.until - self.from) * 1_000_000_000,
+                )
+                .encode_to_vec()
+            }
         };
 
         let mut labels: Vec<LabelPair> = Vec::with_capacity(2 + self.config.tags.iter().len());

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -1,6 +1,6 @@
 use claims::assert_ok;
 use pyroscope::{
-    backend::{Report, ReportBatch},
+    backend::{Report, ReportBatch, ReportData},
     pyroscope::PyroscopeConfig,
     session::{Session, SessionManager, SessionSignal},
 };
@@ -32,7 +32,7 @@ fn test_session_new() {
 
     let batch = ReportBatch {
         profile_type: "process_cpu".into(),
-        reports: vec![Report::new(HashMap::new())],
+        data: ReportData::Reports(vec![Report::new(HashMap::new())]),
     };
 
     let session = Session::new(1950, config, batch).unwrap();
@@ -54,7 +54,7 @@ fn test_session_send_error() {
 
     let batch = ReportBatch {
         profile_type: "process_cpu".into(),
-        reports: vec![Report::new(HashMap::new())],
+        data: ReportData::Reports(vec![Report::new(HashMap::new())]),
     };
 
     let _session = Session::new(1950, config, batch).unwrap();


### PR DESCRIPTION
## Summary

- Introduces a `ReportData` enum with two variants: `Reports(Vec<Report>)` for structured stack-trace data and `RawPprof(Vec<u8>)` for pre-encoded pprof bytes
- Replaces `reports: Vec<Report>` on `ReportBatch` with `data: ReportData`, making the two report kinds mutually exclusive at the type level
- Removes the `raw_pprof: Option<Vec<u8>>` field from `Report` and the `Report::from_raw_pprof()` constructor
- Replaces the runtime `has_raw_pprof` boolean check and `debug_assert!` in `Session::push()` with a `match` on the enum

## Motivation

Previously, `Report` had a `raw_pprof: Option<Vec<u8>>` field that was only meaningful for the jemalloc backend — every other backend set it to `None`. The session layer used a runtime boolean probe (`has_raw_pprof`) and a `debug_assert!(reports.len() == 1)` to enforce that raw pprof batches contained exactly one report. This was a design smell: the two report kinds (structured stack traces vs pre-encoded pprof) are mutually exclusive and should be modeled as an enum rather than an optional field on every report.

With `ReportData`, the invariant that raw pprof is a single blob (not a vec of reports) is enforced structurally by the type system. The jemalloc backend now returns `ReportData::RawPprof(bytes)` directly, while stack-trace backends return `ReportData::Reports(vec)`.

## Changes

| File | Change |
|------|--------|
| `src/backend/types.rs` | Add `ReportData` enum, update `ReportBatch`, remove `raw_pprof` from `Report` |
| `src/backend/jemalloc.rs` | Use `ReportData::RawPprof` instead of `Report::from_raw_pprof` |
| `src/backend/pprof.rs` | Wrap reports in `ReportData::Reports` |
| `src/session.rs` | Replace boolean probe with `match` on `ReportData` |
| `pyroscope_ffi/python/rust/src/backend.rs` | Wrap reports in `ReportData::Reports` |
| `pyroscope_ffi/ruby/ext/rbspy/src/backend.rs` | Wrap reports in `ReportData::Reports` |
| `tests/session.rs` | Update test batch construction |

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` — all 30 tests pass
- [x] All `kit/*/Cargo.toml` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)