### PR TITLE
fix(ci): use valid extra-files type for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,8 +57,9 @@
       "include-component-in-tag": true,
       "extra-files": [
         {
-          "type": "cargo-toml",
-          "path": "ext/rbspy/Cargo.toml"
+          "type": "toml",
+          "path": "ext/rbspy/Cargo.toml",
+          "jsonpath": "$.package.version"
         }
       ],
       "changelog-sections": [
@@ -83,8 +84,9 @@
       "include-component-in-tag": true,
       "extra-files": [
         {
-          "type": "cargo-toml",
-          "path": "../kindasafe_init/Cargo.toml"
+          "type": "toml",
+          "path": "/kit/kindasafe_init/Cargo.toml",
+          "jsonpath": "$.package.version"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Change `cargo-toml` (unsupported) to `toml` type with explicit `jsonpath: $.package.version` for Ruby and kindasafe extra-files
- Fix path traversal in kindasafe extra-files (`../kindasafe_init/Cargo.toml` → `/kit/kindasafe_init/Cargo.toml`)

Every release-please run was failing with: `unsupported extraFile type: cargo-toml`

## Test plan
- [ ] Merge PR and verify release-please workflow succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)