### PR TITLE
fix(ci): configure release-please to update Cargo.lock

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,12 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
       "include-component-in-tag": true,
-      "extra-files": [],
+      "extra-files": [
+        {
+          "type": "cargo-workspace",
+          "path": "/Cargo.lock"
+        }
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
@@ -33,6 +38,10 @@
         {
           "type": "generic",
           "path": "/pyproject.toml"
+        },
+        {
+          "type": "cargo-workspace",
+          "path": "/Cargo.lock"
         }
       ],
       "changelog-sections": [
@@ -87,6 +96,10 @@
           "type": "toml",
           "path": "/kit/kindasafe_init/Cargo.toml",
           "jsonpath": "$.package.version"
+        },
+        {
+          "type": "cargo-workspace",
+          "path": "/Cargo.lock"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Add `cargo-workspace` extra-files entry for `/Cargo.lock` to all Rust release-please packages (lib, python, kindasafe)
- Fixes the issue where release-please bumps versions in `Cargo.toml` but leaves `Cargo.lock` stale (e.g. PR #450)

## Test plan
- [ ] Merge this PR, then verify next release-please PR includes `Cargo.lock` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)