### PR TITLE
fix(ci): add cargo-workspace plugin to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    }
+  ],
   "packages": {
     ".": {
       "component": "lib",


### PR DESCRIPTION
## Summary
- Add the `cargo-workspace` plugin with `merge: false` to keep separate PRs while enabling automatic `Cargo.lock` updates when versions are bumped
- Fixes the issue where release-please bumps versions in `Cargo.toml` but leaves `Cargo.lock` stale (e.g. PR #450)

## Test plan
- [ ] Merge this PR, then verify next release-please PR includes `Cargo.lock` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)