### PR TITLE
fix(ci): remove invalid cargo-workspace extra-files entries

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,12 +14,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
       "include-component-in-tag": true,
-      "extra-files": [
-        {
-          "type": "cargo-workspace",
-          "path": "/Cargo.lock"
-        }
-      ],
+      "extra-files": [],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},
@@ -44,10 +39,6 @@
         {
           "type": "generic",
           "path": "/pyproject.toml"
-        },
-        {
-          "type": "cargo-workspace",
-          "path": "/Cargo.lock"
         }
       ],
       "changelog-sections": [
@@ -102,10 +93,6 @@
           "type": "toml",
           "path": "/kit/kindasafe_init/Cargo.toml",
           "jsonpath": "$.package.version"
-        },
-        {
-          "type": "cargo-workspace",
-          "path": "/Cargo.lock"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- Remove invalid `cargo-workspace` type from `extra-files` in release-please config
- `cargo-workspace` is a **plugin** type (already added in #455), not an extra-files type
- This fixes the `unsupported extraFile type: cargo-workspace` error breaking release-please

## Test plan
- [ ] Merge and verify release-please workflow succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)