### PR TITLE
fix(ci): remove cargo-workspace plugin that bumps all workspace crates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "merge": false
-    }
-  ],
   "packages": {
     ".": {
       "component": "lib",


### PR DESCRIPTION
## Summary

- Remove the `cargo-workspace` release-please plugin that was causing all workspace crates to be version-bumped together

## Problem

The `cargo-workspace` plugin (added in #455) discovers all workspace members from the root `Cargo.toml` and force-bumps **every** crate to the same version when any configured package is released. This caused [PR #453](https://github.com/grafana/pyroscope-rs/pull/453) to bump all `kit/` crates from `0.1.0` → `2.0.0` and the FFI crates to `2.0.0`, even though:

- The `kit/` crates are internal (`publish = false`) and should not be versioned by release-please
- The FFI crates (`python`, `ruby`) are supposed to be versioned independently — that's the purpose of `separate-pull-requests: true`

## Fix

Remove the `cargo-workspace` plugin entirely. It was originally added to handle `Cargo.lock` updates, but the `rust` release-type [already updates `Cargo.lock` natively](https://github.com/googleapis/release-please/issues/704).

Without the plugin, release-please will only bump the version in the specific package being released (`.`, `pyroscope_ffi/python/rust`, or `pyroscope_ffi/ruby`) without touching `kit/` crates.

## Test plan

- [ ] Merge to main and verify the next release-please PR only bumps the intended package version
- [ ] Verify `Cargo.lock` is still updated in release PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)