### PR TITLE
fix: do not recreate profiling guard, just reset the data

### DIFF
--- a/src/backend/pprof.rs
+++ b/src/backend/pprof.rs
@@ -131,7 +131,7 @@ impl Pprof<'_> {
             .as_ref()
             .ok_or_else(|| PyroscopeError::new("pprof-rs: ProfilerGuard report error"))?
             .report()
-            .build()
+            .build_and_clear(true)
             .map_err(|e| PyroscopeError::new(e.to_string().as_str()))?;
 
         let stack_buffer = Into::<StackBuffer>::into(Into::<StackBufferWrapper>::into((
@@ -153,24 +153,6 @@ impl Pprof<'_> {
         for (stacktrace, count) in data {
             buffer.lock()?.record_with_count(stacktrace, count)?;
         }
-
-        self.reset()?;
-
-        Ok(())
-    }
-
-    pub fn reset(&self) -> Result<()> {
-        drop(self.guard.lock()?.take());
-
-        *self.guard.lock()? = Some(
-            self.inner_builder
-                .lock()?
-                .as_ref()
-                .ok_or_else(|| PyroscopeError::new("pprof-rs: ProfilerGuardBuilder error"))?
-                .clone()
-                .build()
-                .map_err(|e| PyroscopeError::new(e.to_string().as_str()))?,
-        );
 
         Ok(())
     }

--- a/src/backend/pprof.rs
+++ b/src/backend/pprof.rs
@@ -36,7 +36,6 @@ pub struct Pprof<'a> {
     buffer: Arc<Mutex<StackBuffer>>,
     config: PprofConfig,
     backend_config: BackendConfig,
-    inner_builder: Arc<Mutex<Option<ProfilerGuardBuilder>>>,
     guard: Arc<Mutex<Option<ProfilerGuard<'a>>>>,
     ruleset: ThreadTagsSet,
 }
@@ -53,7 +52,6 @@ impl<'a> Pprof<'a> {
             buffer: Arc::new(Mutex::new(StackBuffer::default())),
             config,
             backend_config,
-            inner_builder: Arc::new(Mutex::new(None)),
             guard: Arc::new(Mutex::new(None)),
             ruleset: ThreadTagsSet::default(),
         }
@@ -67,19 +65,12 @@ impl Backend for Pprof<'_> {
     }
 
     fn initialize(&mut self) -> Result<()> {
-        let profiler = ProfilerGuardBuilder::default().frequency(self.config.sample_rate as i32);
+        let profiler = ProfilerGuardBuilder::default()
+            .frequency(self.config.sample_rate as i32)
+            .build()
+            .map_err(|e| PyroscopeError::new(e.to_string().as_str()))?;
 
-        *self.inner_builder.lock()? = Some(profiler);
-
-        *self.guard.lock()? = Some(
-            self.inner_builder
-                .lock()?
-                .as_ref()
-                .ok_or_else(|| PyroscopeError::new("pprof-rs: ProfilerGuardBuilder error"))?
-                .clone()
-                .build()
-                .map_err(|e| PyroscopeError::new(e.to_string().as_str()))?,
-        );
+        *self.guard.lock()? = Some(profiler);
 
         Ok(())
     }


### PR DESCRIPTION
- use `build_and_clear` instead of `build` (does not clear)-
- remove `reset` function recreating.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how profiling samples are cleared and retained by switching to `build_and_clear` and removing guard re-creation, which could affect profile continuity or sampling correctness if `pprof` semantics differ across platforms.
> 
> **Overview**
> **Pprof backend now clears collected samples without recreating the profiler.** Initialization builds a `ProfilerGuard` once and stores it directly, removing the extra cached `ProfilerGuardBuilder` and the `reset()` path.
> 
> When dumping a report, it now uses `build_and_clear(true)` so the underlying `pprof` data is cleared after each report, avoiding the previous guard drop/rebuild cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52ae9efb5538c692c86247edd6ffd67d5bdeefb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->