### PR TITLE
fix!: remove dynamic thread tag support

### DIFF
--- a/src/backend/pprof.rs
+++ b/src/backend/pprof.rs
@@ -38,7 +38,6 @@ pub struct Pprof<'a> {
     backend_config: BackendConfig,
     inner_builder: Arc<Mutex<Option<ProfilerGuardBuilder>>>,
     guard: Arc<Mutex<Option<ProfilerGuard<'a>>>>,
-    ruleset: ThreadTagsSet,
 }
 
 impl std::fmt::Debug for Pprof<'_> {
@@ -55,7 +54,6 @@ impl<'a> Pprof<'a> {
             backend_config,
             inner_builder: Arc::new(Mutex::new(None)),
             guard: Arc::new(Mutex::new(None)),
-            ruleset: ThreadTagsSet::default(),
         }
     }
 }
@@ -101,24 +99,12 @@ impl Backend for Pprof<'_> {
         })
     }
 
-    fn add_tag(&self, tag: ThreadTag) -> Result<()> {
-        if self.guard.lock()?.as_ref().is_some() {
-            self.dump_report()?;
-        }
-
-        self.ruleset.add(tag)?;
-
-        Ok(())
+    fn add_tag(&self, _tag: ThreadTag) -> Result<()> {
+        Err(PyroscopeError::Unimplemented)
     }
 
-    fn remove_tag(&self, tag: ThreadTag) -> Result<()> {
-        if self.guard.lock()?.as_ref().is_some() {
-            self.dump_report()?;
-        }
-
-        self.ruleset.remove(tag)?;
-
-        Ok(())
+    fn remove_tag(&self, _tag: ThreadTag) -> Result<()> {
+        Err(PyroscopeError::Unimplemented)
     }
 }
 
@@ -139,19 +125,11 @@ impl Pprof<'_> {
             &self.backend_config,
         )));
 
-        let data: HashMap<StackTrace, usize> = stack_buffer
-            .data
-            .iter()
-            .map(|(stacktrace, ss)| {
-                let stacktrace = stacktrace.to_owned().add_tag_rules(&self.ruleset);
-                (stacktrace, ss.to_owned())
-            })
-            .collect();
-
-        let buffer = self.buffer.clone();
-
-        for (stacktrace, count) in data {
-            buffer.lock()?.record_with_count(stacktrace, count)?;
+        {
+            let mut buffer = self.buffer.lock()?;
+            for (stacktrace, count) in stack_buffer.data {
+                buffer.record_with_count(stacktrace, count)?;
+            }
         }
 
         self.reset()?;

--- a/src/backend/pprof.rs
+++ b/src/backend/pprof.rs
@@ -1,6 +1,6 @@
 use crate::backend::{
     Backend, BackendConfig, BackendImpl, BackendUninitialized, Report, ReportBatch, ReportData,
-    StackBuffer, StackFrame, StackTrace, ThreadTag, ThreadTagsSet,
+    StackBuffer, StackFrame, StackTrace, ThreadTag,
 };
 use crate::error::{PyroscopeError, Result};
 use pprof::{ProfilerGuard, ProfilerGuardBuilder};

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ pub type Result<T> = std::result::Result<T, PyroscopeError>;
 pub enum PyroscopeError {
     #[error("Other: {}", &.0)]
     AdHoc(String),
+    #[error("Unimplemented")]
+    Unimplemented,
 
     #[error("{msg}: {source:?}")]
     Compat {


### PR DESCRIPTION
Current implementation resets the profiler on each tag addition/removal which in turn recreates the whole profiler at least until https://github.com/grafana/pyroscope-rs/pull/518 which is pretty bad.
return PyroscopeError::Unimplemented until we have a better implementation

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `pprof` backend behavior so `add_tag`/`remove_tag` now return an error instead of updating tag rules, which may break callers relying on dynamic thread tagging. Also alters how samples are recorded during `dump_report`, so tagging-related attribution changes for `pprof-rs` users.
> 
> **Overview**
> **Disables dynamic thread tagging in the `pprof-rs` backend.** The `Pprof` backend no longer maintains a `ThreadTagsSet` or rewrites stack traces with tag rules during `dump_report`.
> 
> Calls to `Backend::add_tag` and `Backend::remove_tag` on the `pprof` backend now return `PyroscopeError::Unimplemented` (new error variant), rather than forcing a profiler reset and applying tag updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee377273787bbef3936ebdd0182a03f278ce773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->