### PR TITLE
fix: remove kindasafe CI leftovers

### DIFF
--- a/.github/workflows/publish-rust-crate.yml
+++ b/.github/workflows/publish-rust-crate.yml
@@ -31,30 +31,3 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-  publish-kindasafe:
-    name: kindasafe
-    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-large' || 'ubuntu-latest' }}
-    if: "startsWith(github.event.release.tag_name, 'kindasafe-')"
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-        with:
-          toolchain: 1.88.0
-      - name: Authenticate with crates.io
-        id: auth
-        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
-      - name: publish kindasafe crate
-        run: cargo publish --manifest-path kit/kindasafe/Cargo.toml
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-      - name: wait for crates.io index
-        run: sleep 15
-      - name: publish kindasafe_init crate
-        run: cargo publish --manifest-path kit/kindasafe_init/Cargo.toml
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a GitHub Actions job used for releasing `kindasafe` crates, without affecting build or runtime code.
> 
> **Overview**
> Removes the `publish-kindasafe` job from `.github/workflows/publish-rust-crate.yml`, so releases tagged `kindasafe-*` will no longer publish the `kindasafe` and `kindasafe_init` crates to crates.io (including the index wait step). The workflow now only publishes the `pyroscope` crate for `lib-*` release tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6f4edfbfc808b3e37fd8e499acd93481feb5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->