### PR TITLE
style: inline format args in format/log/assert macros

### DIFF
--- a/examples/jemalloc.rs
+++ b/examples/jemalloc.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         iteration += 1;
     }
-    eprintln!("Completed {} iterations", iteration);
+    eprintln!("Completed {iteration} iterations");
 
     let agent_ready = agent_running.stop()?;
     agent_ready.shutdown();

--- a/src/backend/jemalloc.rs
+++ b/src/backend/jemalloc.rs
@@ -69,7 +69,7 @@ impl Backend for Jemalloc {
         })?;
         let pprof_data = guard
             .dump_pprof()
-            .map_err(|e| PyroscopeError::new(&format!("jemalloc: dump_pprof failed: {}", e)))?;
+            .map_err(|e| PyroscopeError::new(&format!("jemalloc: dump_pprof failed: {e}")))?;
 
         Ok(ReportBatch {
             profile_type: "memory".into(),

--- a/src/backend/tests.rs
+++ b/src/backend/tests.rs
@@ -16,7 +16,7 @@ fn test_stack_frame_display() {
         Some(1),
     );
 
-    assert_eq!(format!("{}", frame), "filename:1 - name");
+    assert_eq!(format!("{frame}"), "filename:1 - name");
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_stack_trace_display() {
     let stack_trace = StackTrace::new(&BackendConfig::default(), None, None, None, frames);
 
     assert_eq!(
-        format!("{}", stack_trace),
+        format!("{stack_trace}"),
         "filename:2 - name;filename:1 - name"
     );
 }

--- a/src/backend/types.rs
+++ b/src/backend/types.rs
@@ -200,7 +200,7 @@ impl std::fmt::Display for StackTrace {
                 .frames
                 .iter()
                 .rev()
-                .map(|frame| format!("{}", frame))
+                .map(|frame| format!("{frame}"))
                 .collect::<Vec<_>>()
                 .join(";")
         )

--- a/src/ffikit.rs
+++ b/src/ffikit.rs
@@ -39,18 +39,18 @@ pub fn run(agent: PyroscopeAgentBuilder) -> Result<()> {
             match signal {
                 Signal::Kill => {
                     if let Err(err) = stop(agent) {
-                        log::error!(target: TAG, "failed to stop agent {}", err);
+                        log::error!(target: TAG, "failed to stop agent {err}");
                     }
                     break;
                 }
                 Signal::AddThreadTag(thread_id, tag) => {
                     if let Err(err) = agent.add_thread_tag(thread_id, tag) {
-                        log::error!(target: TAG, "failed to add tag {}", err);
+                        log::error!(target: TAG, "failed to add tag {err}");
                     }
                 }
                 Signal::RemoveThreadTag(thread_id, tag) => {
                     if let Err(err) = agent.remove_thread_tag(thread_id, tag) {
-                        log::error!(target: TAG, "failed to remove tag {}", err);
+                        log::error!(target: TAG, "failed to remove tag {err}");
                     }
                 }
             }

--- a/src/pyroscope.rs
+++ b/src/pyroscope.rs
@@ -418,7 +418,7 @@ impl<S: PyroscopeAgentState> PyroscopeAgent<S> {
         // Shutdown Backend
         match self.backend.shutdown() {
             Ok(_) => log::debug!(target: LOG_TAG, "Backend shutdown"),
-            Err(e) => log::error!(target: LOG_TAG, "Backend shutdown error: {}", e),
+            Err(e) => log::error!(target: LOG_TAG, "Backend shutdown error: {e}"),
         }
 
         // Drop Timer listeners
@@ -506,7 +506,7 @@ impl PyroscopeAgent<PyroscopeAgentReady> {
             while let Ok(signal) = rx.recv() {
                 match signal {
                     TimerSignal::NextSnapshot(until) => {
-                        log::trace!(target: LOG_TAG, "Sending session {}", until);
+                        log::trace!(target: LOG_TAG, "Sending session {until}");
 
                         // Generate report from backend
                         let report = backend
@@ -674,14 +674,13 @@ pub fn parse_http_headers_json(http_headers_json: String) -> Result<HashMap<Stri
     let parsed: serde_json::Value = serde_json::from_str(&http_headers_json)?;
     let parsed = parsed
         .as_object()
-        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected object, got {}", parsed)))?;
+        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected object, got {parsed}")))?;
     for (k, v) in parsed {
         if let Some(value) = v.as_str() {
             http_headers.insert(k.to_string(), value.to_string());
         } else {
             return Err(PyroscopeError::AdHoc(format!(
-                "invalid http header value, not a string: {}",
-                v
+                "invalid http header value, not a string: {v}"
             )));
         }
     }
@@ -692,15 +691,14 @@ pub fn parse_vec_string_json(s: String) -> Result<Vec<String>> {
     let parsed: serde_json::Value = serde_json::from_str(&s)?;
     let parsed = parsed
         .as_array()
-        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected array, got {}", parsed)))?;
+        .ok_or_else(|| PyroscopeError::AdHoc(format!("expected array, got {parsed}")))?;
     let mut res = Vec::with_capacity(parsed.len());
     for v in parsed {
         if let Some(s) = v.as_str() {
             res.push(s.to_string());
         } else {
             return Err(PyroscopeError::AdHoc(format!(
-                "invalid element value, not a string: {}",
-                v
+                "invalid element value, not a string: {v}"
             )));
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -60,7 +60,7 @@ impl SessionManager {
                         // the SessionManager thread if the server is not available.
                         match (*session).push(&client) {
                             Ok(_) => log::trace!("SessionManager - Session sent"),
-                            Err(e) => log::error!("SessionManager - Failed to send session: {}", e),
+                            Err(e) => log::error!("SessionManager - Failed to send session: {e}"),
                         }
                     }
                     SessionSignal::Kill => {

--- a/src/timer/epoll.rs
+++ b/src/timer/epoll.rs
@@ -72,7 +72,7 @@ impl Timer {
                     // Get the current time range
                     let from = TimerSignal::NextSnapshot(get_time_range(0)?.from);
 
-                    log::trace!(target: LOG_TAG, "Timer fired @ {}", from);
+                    log::trace!(target: LOG_TAG, "Timer fired @ {from}");
 
                     // Iterate through Senders
                     txs.lock()?.iter().for_each(|tx| {

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -14,7 +14,7 @@ impl std::fmt::Display for TimerSignal {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Terminate => write!(f, "Terminate"),
-            Self::NextSnapshot(when) => write!(f, "NextSnapshot({})", when),
+            Self::NextSnapshot(when) => write!(f, "NextSnapshot({when})"),
         }
     }
 }


### PR DESCRIPTION
Apply `cargo clippy --fix` for the `uninlined_format_args` lint across the crate. Mechanical replacement of `"{}", var` with `"{var}"` in `format!`, `log::*!`, `write!`, `eprintln!`, and `assert_eq!` call sites. No behavior change.

The lint already errors locally on stable Rust 1.88 (`cargo clippy --locked --workspace --all-targets --all-features -- --deny warnings`), which matches the exact command CI runs. CI currently passes on main only because the hosted stable runner resolves to a newer toolchain that no longer flags this lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical formatting-only changes across logging, errors, and tests; no control flow or data handling logic is modified.
> 
> **Overview**
> Replaces legacy `"{}", var` formatting patterns with Rust’s *inlined format arguments* (e.g., `"{var}"`) across the crate.
> 
> This touches `format!` error construction, `log::*` messages, `write!`/`eprintln!` output, and a few `assert_eq!` call sites (including jemalloc backend/reporting, agent shutdown/session/timer logs, and JSON parse error messages) to satisfy Clippy’s `uninlined_format_args` lint without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c069643a615a2d6294e5065731c8a946eef47057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->