### PR TITLE
fix(epoll): use libc::c_long for itimerspec fields

### DIFF
--- a/src/timer/epoll.rs
+++ b/src/timer/epoll.rs
@@ -114,11 +114,11 @@ impl Timer {
         // new_value sets the Timer
         let mut new_value = libc::itimerspec {
             it_interval: libc::timespec {
-                tv_sec: cycle.as_secs() as i64,
-                tv_nsec: cycle.subsec_nanos() as i64,
+                tv_sec: cycle.as_secs() as libc::c_long,
+                tv_nsec: cycle.subsec_nanos() as libc::c_long,
             },
             it_value: libc::timespec {
-                tv_sec: first_fire as i64,
+                tv_sec: first_fire as libc::c_long,
                 tv_nsec: 0,
             },
         };


### PR DESCRIPTION
`itimerspec.tv_sec` and `tv_nsec` are typed as `c_long` by `libc`, which is `i32` on 32-bit targets (e.g. armv7) and `i64` on 64-bit targets. The previous `i64` casts caused a type mismatch compile error on armv7.

Ran into this issue while trying to compile for Cadmus.

Ref: https://github.com/OGKevin/cadmus/issues/403

---

```bash
$ cargo build --release --target arm-unknown-linux-gnueabihf -p cadmus --features otel,test
   Compiling cadmus-core v0.10.0 (/home/kevin/code/github.com/ogkevin/plato/crates/core)
   Compiling pyroscope v2.0.2 (/home/kevin/code/github.com/ogkevin/plato/vendor/pyroscope)
   Compiling cadmus v0.10.0 (/home/kevin/code/github.com/ogkevin/plato/crates/cadmus)
warning: unstable feature specified for `-Ctarget-feature`: `v7`
  |
  = note: this feature is not stably supported; its behavior can change in the future

warning: unstable feature specified for `-Ctarget-feature`: `vfp3`
  |
  = note: this feature is not stably supported; its behavior can change in the future

warning: unstable feature specified for `-Ctarget-feature`: `neon`
  |
  = note: this feature is not stably supported; its behavior can change in the future

error[E0308]: mismatched types
   --> vendor/pyroscope/src/timer/epoll.rs:117:25
    |
117 |                 tv_sec: cycle.as_secs() as i64,
    |                         ^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

error[E0308]: mismatched types
   --> vendor/pyroscope/src/timer/epoll.rs:118:26
    |
118 |                 tv_nsec: cycle.subsec_nanos() as i64,
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

error[E0308]: mismatched types
   --> vendor/pyroscope/src/timer/epoll.rs:121:25
    |
121 |                 tv_sec: first_fire as i64,
    |                         ^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`

For more information about this error, try `rustc --explain E0308`.
warning: `pyroscope` (lib) generated 3 warnings
error: could not compile `pyroscope` (lib) due to 3 previous errors; 3 warnings emitted
warning: build failed, waiting for other jobs to finish...
```

---

I believe this is an obvious bug and requires no issue, nevertheless, I'm happy to open one if needed 🤝 .

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-cast change to fix cross-platform compilation; behavior should be unchanged aside from using the correct libc field types on 32-bit targets.
> 
> **Overview**
> Fixes `src/timer/epoll.rs` timerfd setup by casting `itimerspec` `tv_sec`/`tv_nsec` assignments to `libc::c_long` instead of `i64`, resolving type-mismatch build failures on 32-bit Linux targets (e.g., armv7) while keeping timer behavior the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a791dabe1bf202a1d92bf50b62ce19baac937b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->