### PR TITLE
ci: add ARM cross-compilation test job

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -80,3 +80,14 @@ jobs:
 
       - name: Run tests
         run: docker build --progress=plain --build-arg BASE_IMAGE=${{ matrix.libc.base_image }} -f ci/test.Dockerfile .
+
+  cross-compile-arm:
+    name: cross-compile arm
+    runs-on: ${{ github.repository_owner == 'grafana' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Cross-compile to ARM
+        run: make rust/cross-compile/arm

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ rust/fmt:
 rust/fmt/check:
 	cargo fmt --all --check
 
+.PHONY: rust/cross-compile/arm
+rust/cross-compile/arm:
+	docker build -t pyroscope-arm-cross -f ci/Dockerfile.arm-cross .
+	docker run --rm -v $(shell pwd):/work pyroscope-arm-cross cargo build --locked --target arm-unknown-linux-gnueabi --all-features
+
 .PHONY: check/lib-tag-version
 check/lib-tag-version:
 	@TAG_VERSION=$${TAG#lib-}; \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ rust/fmt/check:
 
 .PHONY: rust/cross-compile/arm
 rust/cross-compile/arm:
-	docker build -t pyroscope-arm-cross -f ci/Dockerfile.arm-cross .
+	docker build -t pyroscope-arm-cross -f ci/Dockerfile.arm-cross ci
 	docker run --rm -v $(shell pwd):/work pyroscope-arm-cross cargo build --locked --target arm-unknown-linux-gnueabi --all-features
 
 .PHONY: check/lib-tag-version

--- a/ci/Dockerfile.arm-cross
+++ b/ci/Dockerfile.arm-cross
@@ -1,0 +1,17 @@
+FROM rust:latest
+
+RUN apt-get update -qq \
+ && apt-get install -y -qq --no-install-recommends \
+      gcc-arm-linux-gnueabi \
+      binutils-arm-linux-gnueabi \
+      libc6-dev-armel-cross \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add arm-unknown-linux-gnueabi
+
+ENV CC_arm_unknown_linux_gnueabi=arm-linux-gnueabi-gcc \
+    AR_arm_unknown_linux_gnueabi=arm-linux-gnueabi-ar \
+    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
+    CARGO_TARGET_DIR=/work/target/docker-arm
+
+WORKDIR /work


### PR DESCRIPTION
This PR adds a new CI job to test cross-compilation to ARM.
It uses a Docker container as a build environment and a Makefile target for the build logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only changes adding a cross-compilation build check; main risk is increased CI time or flaky builds due to Docker/ARM toolchain setup.
> 
> **Overview**
> Adds a new `cross-compile-arm` job to the Rust GitHub Actions workflow to ensure the codebase can be cross-compiled for `arm-unknown-linux-gnueabi`.
> 
> Introduces a `make rust/cross-compile/arm` target and a new `ci/Dockerfile.arm-cross` image that installs the ARM GCC toolchain, configures Cargo linker env vars, and runs `cargo build --locked --all-features` for that target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc9138676ea291b8c06dd711e5ae41e3bfdd528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->