### PR TITLE
chore(renovate): remove openssl rules and custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,41 +5,11 @@
   ],
   "packageRules": [
     {
-      "matchDepNames": [
-        "openssl/openssl"
-      ],
-      "separateMinorPatch": true
-    },
-    {
-      "matchDepNames": [
-        "openssl/openssl"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "enabled": false
-    },
-    {
       "description": "Allow all updates for critical profiling dependencies",
       "matchDepNames": [
         "pprof-pyroscope-fork"
       ],
       "enabled": true
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^docker/.*\\.Dockerfile$/"
-      ],
-      "matchStrings": [
-        "ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"
-      ],
-      "depNameTemplate": "openssl/openssl",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^openssl-(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Removes the openssl-specific packageRules and the customManager that scanned docker/*.Dockerfile files for ARG OPENSSL_VERSION. Neither the docker directory nor any Dockerfile defining OPENSSL_VERSION exists in this repo, so the rules were dead config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)