### PR TITLE
chore(renovate): vulnerabilities-only with profiling deps allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "assert_matches",
  "claims",
  "env_logger",
+ "framehop",
  "jemalloc_pprof",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ libc = "^0.2.124"
 prost = "0.14"
 serde_json = "1.0.115"
 pprof = { package = "pprof-pyroscope-fork", version = "0.1500.2", features = ["framehop", "framehop-unwinder"], optional = true }
+framehop = { version = "0.13", optional = true }
 lazy_static = "1.5.0"
 jemalloc_pprof = { version = "0.8", features = ["symbolize"], optional = true }
 
@@ -49,7 +50,7 @@ rustls-tls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 rustls-no-provider = ["reqwest/rustls-no-provider"]
-backend-pprof-rs = ["dep:pprof"]
+backend-pprof-rs = ["dep:pprof", "dep:framehop"]
 backend-jemalloc = ["dep:jemalloc_pprof"]
 
 [profile.dev]

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,9 @@
     {
       "description": "Always update these to latest, all update types. Overrides the wildcard enabled:false from security:only-security-updates.",
       "matchPackageNames": [
-        "pprof-pyroscope-fork"
+        "pprof-pyroscope-fork",
+        "jemalloc_pprof",
+        "framehop"
       ],
       "enabled": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -1,45 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "security:only-security-updates"
   ],
   "packageRules": [
     {
-      "matchDepNames": [
-        "openssl/openssl"
-      ],
-      "separateMinorPatch": true
-    },
-    {
-      "matchDepNames": [
-        "openssl/openssl"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Allow all updates for critical profiling dependencies",
-      "matchDepNames": [
+      "description": "Always update these to latest, all update types. Overrides the wildcard enabled:false from security:only-security-updates.",
+      "matchPackageNames": [
         "pprof-pyroscope-fork"
       ],
       "enabled": true
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^docker/.*\\.Dockerfile$/"
-      ],
-      "matchStrings": [
-        "ARG OPENSSL_VERSION=(?<currentValue>[\\d.]+)"
-      ],
-      "depNameTemplate": "openssl/openssl",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^openssl-(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
Switches renovate to extend the built-in `security:only-security-updates` preset, then adds an explicit allowlist for `pprof-pyroscope-fork`, `jemalloc_pprof`, and `framehop` so those three are the only deps that get routine update PRs; everything else (cargo deps, github-actions, the `rust:trixie` base image) only gets a PR in response to an OSV or GHSA advisory.

Drops the `openssl/openssl` packageRules and the custom regex manager for `ARG OPENSSL_VERSION`. Those targeted `docker/gem.Dockerfile`, `docker/wheel.Dockerfile`, and `docker/wheel-musllinux.Dockerfile`, which live in the language-specific repos now (pyroscope-ruby, pyroscope-python). The `docker/` directory no longer exists here, so the manager's `^docker/.*\.Dockerfile$` pattern never matched and the openssl rules had nothing to apply to.

Promotes `framehop` from a transitive dep (pulled in by `pprof-pyroscope-fork`'s `framehop` feature) to a direct optional dep in `Cargo.toml`, wired into the `backend-pprof-rs` feature. Renovate's cargo manager only updates deps declared directly in `Cargo.toml`, so without this promotion the `framehop` allowlist entry would be a no-op (Cursor Bugbot flagged this on an earlier revision). Build behavior is unchanged: `framehop` is still only compiled when the pprof backend is enabled, and cargo unifies our declaration with the one inside `pprof-pyroscope-fork`.

Mirrors https://github.com/grafana/pyroscope-ruby/pull/71.