### PR TITLE
ci: Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   check-title:
     name: Validate PR Title


### PR DESCRIPTION
Potential fix for [https://github.com/grafana/pyroscope-rs/security/code-scanning/14](https://github.com/grafana/pyroscope-rs/security/code-scanning/14)

Add an explicit `permissions` block to `.github/workflows/pr-title-check.yml` at the workflow root (top-level), just below the `on:` trigger section and before `jobs:`.  
For this workflow, the minimal safe permission is:

- `contents: read`

This preserves existing functionality (the script only reads `github.event.pull_request.title` from event payload and does not need write scopes). No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk YAML-only change that tightens GitHub Actions permissions to `contents: read` without altering job logic.
> 
> **Overview**
> Adds an explicit top-level `permissions` block (`contents: read`) to `.github/workflows/pr-title-check.yml` to satisfy code-scanning guidance and ensure the PR title validation workflow runs with minimal read-only privileges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8ec28d8387ebdd8e75ca1dc3eacb8ad5588aae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->