### PR TITLE
chore(deps): Remove unnecessary framehop dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,14 +458,14 @@ dependencies = [
 
 [[package]]
 name = "framehop"
-version = "0.13.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a5a3f0acb82df800ca3aa50c0d60d286c5d13d4cfc3114b3a9663f13b032fe"
+checksum = "6f54fe4785e899d4d6f43793b151c63c5647240fc630b005509d2614a939f693"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "fallible-iterator",
- "gimli 0.31.1",
+ "gimli 0.33.0",
  "macho-unwind-info",
  "pe-unwind-info",
 ]
@@ -567,19 +567,18 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1332,9 +1331,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pe-unwind-info"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500fa4cdeacd98997c5865e3d0d1cb8fe7e9d7d75ecc775e07989a433a9a9a59"
+checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -1387,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "pprof-pyroscope-fork"
-version = "0.1500.3"
+version = "0.1500.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f090659c6f3f8c12785dabca0cb7f40154a40dc254c06848598ff31c3be1d8"
+checksum = "228f0967ab4c785d2daa6afdecd844a85a08227b19bfe14f1cf3f7819bf42f43"
 dependencies = [
  "aligned-vec",
  "backtrace",
@@ -1481,7 +1480,6 @@ dependencies = [
  "assert_matches",
  "claims",
  "env_logger",
- "framehop",
  "jemalloc_pprof",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ libflate = "2.1.0"
 libc = "^0.2.124"
 prost = "0.14"
 serde_json = "1.0.115"
-pprof = { package = "pprof-pyroscope-fork", version = "0.1500.2", features = ["framehop", "framehop-unwinder"], optional = true }
-framehop = { version = "0.13", optional = true }
+pprof = { package = "pprof-pyroscope-fork", version = "0.1500.4", features = ["framehop", "framehop-unwinder"], optional = true }
 lazy_static = "1.5.0"
 jemalloc_pprof = { version = "0.8", features = ["symbolize"], optional = true }
 
@@ -49,7 +48,7 @@ rustls-tls = ["reqwest/rustls"]
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 rustls-no-provider = ["reqwest/rustls-no-provider"]
-backend-pprof-rs = ["dep:pprof", "dep:framehop"]
+backend-pprof-rs = ["dep:pprof"]
 backend-jemalloc = ["dep:jemalloc_pprof"]
 
 [profile.dev]


### PR DESCRIPTION
`cargo deny` flagged this for me.

```md
error[duplicate]: found 2 duplicate entries for crate 'framehop'
    ┌─ /__w/bedev-framework-rust/bedev-framework-rust/Cargo.lock:144:1
    │  
144 │ ╭ framehop 0.13.3 registry+https://github.com/rust-lang/crates.io-index
145 │ │ framehop 0.16.0 registry+https://github.com/rust-lang/crates.io-index
    │ ╰─────────────────────────────────────────────────────────────────────┘ lock entries
    │  
    ├ framehop v0.13.3
      └── pyroscope v2.0.4
          └── roblox-profiling v0.173.0
              └── ...
    ├ framehop v0.16.0
      └── pprof-pyroscope-fork v0.1500.4
          └── pyroscope v2.0.4
              └── roblox-profiling v0.173.0
                   ...
```

Upon closer inspection, I found the dependency here is unnecessary, it comes exclusively from `pyroscope-pprof-rs`. 
I figured it would be ok to simply drop it. Please let me know if I missed something!

Note that the patch version bump on `pprof-pyroscope-fork` is a no-op for consumers because cargo update picks it up anyway for consumers since the dependency is not pinned to an exact version.