### PR TITLE
Bump jemalloc to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,9 +866,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+checksum = "0bb2dfa20a68824f4c8c1aa271617d0ee0d9b707a866d56b7d7ee39c60c235a8"
 dependencies = [
  "anyhow",
  "libc",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libc = "^0.2.124"
 prost = "0.14"
 serde_json = "1.0.115"
 lazy_static = "1.5.0"
-jemalloc_pprof = { version = "0.8", features = ["symbolize"], optional = true }
+jemalloc_pprof = { version = "0.9", features = ["symbolize"], optional = true }
 
 
 # pprofrs dependencies
@@ -51,7 +51,7 @@ symbolic-demangle = { version = "13.1.0", default-features = false, features = [
 [dev-dependencies]
 assert_matches = "=1.5.0"
 claims = "=0.8.0"
-tikv-jemallocator = { version = "=0.6.1", features = ["profiling"] }
+tikv-jemallocator = { version = "0.7", features = ["profiling"] }
 env_logger = "=0.11.10"
 
 [[example]]


### PR DESCRIPTION
Jemalloc has had a new release after years.
We'd love to be able to use it.

The last missing piece was completed in https://github.com/polarsignals/rust-jemalloc-pprof/issues/37

Note: nix is out of date at 0.26 - latest is at 0.31 but I did not touch it to keep this PR less controversial 😄 