### PR TITLE
feat: support memory profiling by adding ProfileType

### DIFF
--- a/src/encode/pprof.rs
+++ b/src/encode/pprof.rs
@@ -27,6 +27,9 @@ pub enum ProfilingType {
     #[default]
     Cpu,
     AllocSpace,
+    AllocObjects,
+    InuseSpace,
+    InuseObjects,
 }
 
 impl ProfilingType {
@@ -35,13 +38,19 @@ impl ProfilingType {
         match self {
             ProfilingType::Cpu => ("cpu", "nanoseconds"),
             ProfilingType::AllocSpace => ("alloc_space", "bytes"),
+            ProfilingType::AllocObjects => ("alloc_objects", "count"),
+            ProfilingType::InuseSpace => ("inuse_space", "bytes"),
+            ProfilingType::InuseObjects => ("inuse_objects", "count"),
         }
     }
 
     fn period(&self, sample_rate: u32) -> i64 {
         match self {
             ProfilingType::Cpu => 1_000_000_000 / sample_rate as i64,
-            ProfilingType::AllocSpace => 1,
+            ProfilingType::AllocSpace
+            | ProfilingType::AllocObjects
+            | ProfilingType::InuseSpace
+            | ProfilingType::InuseObjects => 1,
         }
     }
 }

--- a/src/encode/pprof.rs
+++ b/src/encode/pprof.rs
@@ -22,6 +22,30 @@ pub struct FunctionMirror {
     pub filename: i64,
 }
 
+#[derive(Debug, Default, Copy, Clone)]
+pub enum ProfilingType {
+    #[default]
+    Cpu,
+    AllocSpace,
+}
+
+impl ProfilingType {
+    /// pprof profile types
+    fn value_type(&self) -> (&'static str, &'static str) {
+        match self {
+            ProfilingType::Cpu => ("cpu", "nanoseconds"),
+            ProfilingType::AllocSpace => ("alloc_space", "bytes"),
+        }
+    }
+
+    fn period(&self, sample_rate: u32) -> i64 {
+        match self {
+            ProfilingType::Cpu => 1_000_000_000 / sample_rate as i64,
+            ProfilingType::AllocSpace => 1,
+        }
+    }
+}
+
 impl PProfBuilder {
     fn add_string(&mut self, s: &String) -> i64 {
         let v = self.strings.get(s);
@@ -82,6 +106,7 @@ pub fn encode(
     sample_rate: u32,
     start_time_nanos: u64,
     duration_nanos: u64,
+    profiling_type: &ProfilingType,
 ) -> Profile {
     let mut b = PProfBuilder {
         strings: HashMap::new(),
@@ -106,17 +131,12 @@ pub fn encode(
     };
     b.add_string(&"".to_string());
     {
-        let cpu = b.add_string(&"cpu".to_string());
-        let nanoseconds = b.add_string(&"nanoseconds".to_string());
-        b.profile.sample_type.push(ValueType {
-            r#type: cpu,
-            unit: nanoseconds,
-        });
-        b.profile.period = 1_000_000_000 / sample_rate as i64;
-        b.profile.period_type = Some(ValueType {
-            r#type: cpu,
-            unit: nanoseconds,
-        });
+        let (type_name, unit_name) = profiling_type.value_type();
+        let st = b.add_string(&type_name.to_string());
+        let unit = b.add_string(&unit_name.to_string());
+        b.profile.sample_type.push(ValueType { r#type: st, unit });
+        b.profile.period = profiling_type.period(sample_rate);
+        b.profile.period_type = Some(ValueType { r#type: st, unit });
     }
     for report in reports {
         for (stacktrace, value) in &report.data {

--- a/src/encode/pprof.rs
+++ b/src/encode/pprof.rs
@@ -33,7 +33,7 @@ pub enum ProfilingType {
 }
 
 impl ProfilingType {
-    /// pprof profile types
+    /// pprof `sample_type`: what each sample value means.
     fn value_type(&self) -> (&'static str, &'static str) {
         match self {
             ProfilingType::Cpu => ("cpu", "nanoseconds"),
@@ -41,6 +41,18 @@ impl ProfilingType {
             ProfilingType::AllocObjects => ("alloc_objects", "count"),
             ProfilingType::InuseSpace => ("inuse_space", "bytes"),
             ProfilingType::InuseObjects => ("inuse_objects", "count"),
+        }
+    }
+
+    /// pprof `period_type`. Pyroscope builds the canonical profile type as
+    /// `<name>:<sample_type>:<unit>:<period_type>:<period_unit>`
+    fn period_type(&self) -> (&'static str, &'static str) {
+        match self {
+            ProfilingType::Cpu => ("cpu", "nanoseconds"),
+            ProfilingType::AllocSpace
+            | ProfilingType::AllocObjects
+            | ProfilingType::InuseSpace
+            | ProfilingType::InuseObjects => ("space", "bytes"),
         }
     }
 
@@ -145,7 +157,13 @@ pub fn encode(
         let unit = b.add_string(&unit_name.to_string());
         b.profile.sample_type.push(ValueType { r#type: st, unit });
         b.profile.period = profiling_type.period(sample_rate);
-        b.profile.period_type = Some(ValueType { r#type: st, unit });
+        let (period_name, period_unit_name) = profiling_type.period_type();
+        let period_type = b.add_string(&period_name.to_string());
+        let period_unit = b.add_string(&period_unit_name.to_string());
+        b.profile.period_type = Some(ValueType {
+            r#type: period_type,
+            unit: period_unit,
+        });
     }
     for report in reports {
         for (stacktrace, value) in &report.data {

--- a/src/pyroscope.rs
+++ b/src/pyroscope.rs
@@ -11,6 +11,7 @@ use std::{
 
 use crate::{
     backend::{BackendReady, BackendUninitialized, Report, Tag},
+    encode::pprof::ProfilingType,
     error::Result,
     session::{Session, SessionManager, SessionSignal},
     timer::{Timer, TimerSignal},
@@ -51,6 +52,7 @@ pub struct PyroscopeConfig {
     pub tenant_id: Option<String>,
     pub http_headers: HashMap<String, String>,
     pub upload_interval: Duration,
+    pub profiling_type: ProfilingType,
 }
 
 #[derive(Clone, Debug)]
@@ -73,6 +75,7 @@ impl Default for PyroscopeConfig {
             tenant_id: None,
             http_headers: HashMap::new(),
             upload_interval: Duration::from_secs(10),
+            profiling_type: ProfilingType::default(),
         }
     }
 }
@@ -104,6 +107,7 @@ impl PyroscopeConfig {
             tenant_id: None,
             http_headers: HashMap::new(),
             upload_interval: Duration::from_secs(10),
+            profiling_type: ProfilingType::default(),
         }
     }
 
@@ -170,6 +174,13 @@ impl PyroscopeConfig {
     pub fn upload_interval(self, upload_interval: Duration) -> Self {
         Self {
             upload_interval,
+            ..self
+        }
+    }
+
+    pub fn profiling_type(self, profiling_type: ProfilingType) -> Self {
+        Self {
+            profiling_type,
             ..self
         }
     }
@@ -323,6 +334,13 @@ impl PyroscopeAgentBuilder {
     pub fn upload_interval(self, upload_interval: Duration) -> Self {
         Self {
             config: self.config.upload_interval(upload_interval),
+            ..self
+        }
+    }
+
+    pub fn profiling_type(self, profiling_type: ProfilingType) -> Self {
+        Self {
+            config: self.config.profiling_type(profiling_type),
             ..self
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -147,6 +147,7 @@ impl Session {
                     self.config.sample_rate,
                     self.from * 1_000_000_000,
                     (self.until - self.from) * 1_000_000_000,
+                    &self.config.profiling_type,
                 )
                 .encode_to_vec()
             }


### PR DESCRIPTION
Currently, only CPU is supported in this SDK. This PR adds support for memory profiling by adding a new ProfileType to PyroscopeConfig, which is used by pprof::encode to configure the report sent to the pyroscope server. Closes #564. 

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
