### PR TITLE
chore: bump nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,12 +172,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -1130,12 +1124,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1259,7 +1254,7 @@ version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1319,7 +1314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97f6fccfd2d9d2df765ca23ff85fe5cc437fb0e6d3e164e4d3cbe09d14780c93"
 dependencies = [
  "arrayvec",
- "bitflags 2.11.1",
+ "bitflags",
  "thiserror",
  "zerocopy",
  "zerocopy-derive",
@@ -1689,7 +1684,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1822,7 +1817,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2167,7 +2162,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -2419,7 +2414,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2711,7 +2706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ jemalloc_pprof = { version = "0.9", features = ["symbolize"], optional = true }
 # pprofrs dependencies
 backtrace = { version = "0.3", optional = true }
 once_cell = { version = "1.9", optional = true }
-nix = { version = "0.26", default-features = false, features = ["signal", "fs"], optional = true }
+nix = { version = "0.31", default-features = false, features = ["signal", "fs"], optional = true }
 spin = { version = "0.12", optional = true }
 tempfile = { version = "3.1", optional = true }
 findshlibs = { version = "0.10", optional = true }

--- a/src/backend/pprofrs/addr_validate.rs
+++ b/src/backend/pprofrs/addr_validate.rs
@@ -1,26 +1,18 @@
-use std::{
-    mem::size_of,
-    sync::atomic::{AtomicI32, Ordering},
-};
-
 use nix::{
     errno::Errno,
-    unistd::{close, read, write},
+    unistd::{read, write},
 };
+use std::mem::size_of;
+use std::os::fd::OwnedFd;
 
-struct Pipes {
-    read_fd: AtomicI32,
-    write_fd: AtomicI32,
+#[derive(Default)]
+pub(crate) struct Pipes {
+    read_fd: Option<OwnedFd>,
+    write_fd: Option<OwnedFd>,
 }
-
-static MEM_VALIDATE_PIPE: Pipes = Pipes {
-    read_fd: AtomicI32::new(-1),
-    write_fd: AtomicI32::new(-1),
-};
-
 #[inline]
 #[cfg(any(target_os = "android", target_os = "linux"))]
-fn create_pipe() -> nix::Result<(i32, i32)> {
+fn create_pipe() -> nix::Result<(OwnedFd, OwnedFd)> {
     use nix::fcntl::OFlag;
     use nix::unistd::pipe2;
 
@@ -29,12 +21,11 @@ fn create_pipe() -> nix::Result<(i32, i32)> {
 
 #[inline]
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-fn create_pipe() -> nix::Result<(i32, i32)> {
+fn create_pipe() -> nix::Result<(OwnedFd, OwnedFd)> {
     use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
     use nix::unistd::pipe;
-    use std::os::unix::io::RawFd;
 
-    fn set_flags(fd: RawFd) -> nix::Result<()> {
+    fn set_flags(fd: &OwnedFd) -> nix::Result<()> {
         let mut flags = FdFlag::from_bits(fcntl(fd, FcntlArg::F_GETFD)?).unwrap();
         flags |= FdFlag::FD_CLOEXEC;
         fcntl(fd, FcntlArg::F_SETFD(flags))?;
@@ -45,20 +36,19 @@ fn create_pipe() -> nix::Result<(i32, i32)> {
     }
 
     let (read_fd, write_fd) = pipe()?;
-    set_flags(read_fd)?;
-    set_flags(write_fd)?;
+    set_flags(&read_fd)?;
+    set_flags(&write_fd)?;
     Ok((read_fd, write_fd))
 }
 
-fn open_pipe() -> nix::Result<()> {
-    // ignore the result
-    let _ = close(MEM_VALIDATE_PIPE.read_fd.load(Ordering::SeqCst));
-    let _ = close(MEM_VALIDATE_PIPE.write_fd.load(Ordering::SeqCst));
+fn open_pipe(pipes: &mut Pipes) -> nix::Result<()> {
+    pipes.read_fd = None;
+    pipes.write_fd = None;
 
     let (read_fd, write_fd) = create_pipe()?;
 
-    MEM_VALIDATE_PIPE.read_fd.store(read_fd, Ordering::SeqCst);
-    MEM_VALIDATE_PIPE.write_fd.store(write_fd, Ordering::SeqCst);
+    pipes.read_fd = Some(read_fd);
+    pipes.write_fd = Some(write_fd);
 
     Ok(())
 }
@@ -68,7 +58,7 @@ fn open_pipe() -> nix::Result<()> {
 // if the second argument of `write(ptr, buf)` is not a valid address, the
 // `write()` will return an error the error number should be `EFAULT` in most
 // cases, but we regard all errors (except EINTR) as a failure of validation
-pub fn validate(addr: *const libc::c_void) -> bool {
+pub fn validate(pipes: &mut Pipes, addr: *const libc::c_void) -> bool {
     // it's a short circuit for null pointer, as it'll give an error in
     // `std::slice::from_raw_parts` if the pointer is null.
     if addr.is_null() {
@@ -78,23 +68,29 @@ pub fn validate(addr: *const libc::c_void) -> bool {
     const CHECK_LENGTH: usize = 2 * size_of::<*const libc::c_void>() / size_of::<u8>();
 
     // read data in the pipe
-    let read_fd = MEM_VALIDATE_PIPE.read_fd.load(Ordering::SeqCst);
     let valid_read = loop {
-        let mut buf = [0u8; CHECK_LENGTH];
+        match &pipes.read_fd {
+            None => break false,
+            Some(read_fd) => {
+                let mut buf = [0u8; CHECK_LENGTH];
 
-        match read(read_fd, &mut buf) {
-            Ok(bytes) => break bytes > 0,
-            Err(_err @ Errno::EINTR) => continue,
-            Err(_err @ Errno::EAGAIN) => break true,
-            Err(_) => break false,
+                match read(read_fd, &mut buf) {
+                    Ok(bytes) => break bytes > 0,
+                    Err(_err @ Errno::EINTR) => continue,
+                    Err(_err @ Errno::EAGAIN) => break true,
+                    Err(_) => break false,
+                }
+            }
         }
     };
 
-    if !valid_read && open_pipe().is_err() {
+    if !valid_read && open_pipe(pipes).is_err() {
         return false;
     }
 
-    let write_fd = MEM_VALIDATE_PIPE.write_fd.load(Ordering::SeqCst);
+    let Some(write_fd) = &pipes.write_fd else {
+        return false; // impossible
+    };
     loop {
         let buf = unsafe { std::slice::from_raw_parts(addr as *const u8, CHECK_LENGTH) };
 
@@ -109,26 +105,36 @@ pub fn validate(addr: *const libc::c_void) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use claims::assert_some;
 
     #[test]
     fn validate_stack() {
+        let mut p = Pipes::default();
         let i = 0;
 
-        assert!(validate(&i as *const _ as *const libc::c_void));
+        assert!(validate(&mut p, &i as *const _ as *const libc::c_void));
+        assert_some!(p.read_fd);
+        assert_some!(p.write_fd);
     }
 
     #[test]
     fn validate_heap() {
+        let mut p = Pipes::default();
         let vec = vec![0; 1000];
 
         for i in vec.iter() {
-            assert!(validate(i as *const _ as *const libc::c_void));
+            assert!(validate(&mut p, i as *const _ as *const libc::c_void));
         }
+        assert_some!(p.read_fd);
+        assert_some!(p.write_fd);
     }
 
     #[test]
     fn failed_validate() {
-        assert!(!validate(std::ptr::null::<libc::c_void>()));
-        assert!(!validate(-1_i32 as usize as *const libc::c_void))
+        let mut p = Pipes::default();
+        assert!(!validate(&mut p, std::ptr::null::<libc::c_void>()));
+        assert!(!validate(&mut p, -1_i32 as usize as *const libc::c_void));
+        assert_some!(p.read_fd);
+        assert_some!(p.write_fd);
     }
 }

--- a/src/backend/pprofrs/backtrace/framehop_unwinder.rs
+++ b/src/backend/pprofrs/backtrace/framehop_unwinder.rs
@@ -96,7 +96,11 @@ impl FramehopUnwinder {
         }
         let cache = CacheNative::default();
         let pipes = Pipes::default();
-        FramehopUnwinder { unwinder, cache, pipes}
+        FramehopUnwinder {
+            unwinder,
+            cache,
+            pipes,
+        }
     }
 
     pub fn iter_frames<F: FnMut(&Frame) -> bool>(&mut self, ctx: *mut c_void, mut cb: F) {

--- a/src/backend/pprofrs/backtrace/framehop_unwinder.rs
+++ b/src/backend/pprofrs/backtrace/framehop_unwinder.rs
@@ -1,9 +1,11 @@
+use crate::backend::pprofrs::addr_validate::Pipes;
 use framehop::{
     CacheNative, MustNotAllocateDuringUnwind, UnwindRegsNative, Unwinder, UnwinderNative,
 };
 use libc::{c_void, ucontext_t};
 use once_cell::sync::Lazy;
 use spin::RwLock;
+
 mod shlib;
 
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
@@ -83,6 +85,7 @@ fn get_regs_from_context(ucontext: *mut c_void) -> Option<(UnwindRegsNative, u64
 struct FramehopUnwinder {
     unwinder: UnwinderNative<Vec<u8>, MustNotAllocateDuringUnwind>,
     cache: CacheNative<MustNotAllocateDuringUnwind>,
+    pipes: Pipes,
 }
 
 impl FramehopUnwinder {
@@ -92,7 +95,8 @@ impl FramehopUnwinder {
             unwinder.add_module(obj.clone());
         }
         let cache = CacheNative::default();
-        FramehopUnwinder { unwinder, cache }
+        let pipes = Pipes::default();
+        FramehopUnwinder { unwinder, cache, pipes}
     }
 
     pub fn iter_frames<F: FnMut(&Frame) -> bool>(&mut self, ctx: *mut c_void, mut cb: F) {
@@ -101,7 +105,7 @@ impl FramehopUnwinder {
             None => return,
         };
 
-        let mut closure = |addr| read_stack(addr);
+        let mut closure = |addr| read_stack(&mut self.pipes, addr);
         let mut iter = self
             .unwinder
             .iter_frames(pc, regs, &mut self.cache, &mut closure);
@@ -115,9 +119,9 @@ impl FramehopUnwinder {
     }
 }
 
-fn read_stack(addr: u64) -> Result<u64, ()> {
+fn read_stack(pipes: &mut Pipes, addr: u64) -> Result<u64, ()> {
     let aligned_addr = addr & !0b111;
-    if crate::backend::pprofrs::addr_validate::validate(aligned_addr as _) {
+    if crate::backend::pprofrs::addr_validate::validate(pipes, aligned_addr as _) {
         Ok(unsafe { (aligned_addr as *const u64).read() })
     } else {
         Err(())


### PR DESCRIPTION
Bump `nix` crate.
`nix::pipe` now returns `OwnedFd` instead of `RawFd` breaking `addr_validate` module. To fix - we store `OwnedFd` into `Pipes` and remove global static state `MEM_VALIDATE_PIPE`, storing the `Pipes` in the `FramehopUnwinder` struct.